### PR TITLE
🐛 fix(nvim): fix plugin config bugs found in review

### DIFF
--- a/nvim/.config/nvim/lua/config/keybinds.lua
+++ b/nvim/.config/nvim/lua/config/keybinds.lua
@@ -11,8 +11,8 @@ vim.keymap.set("n", "<c-d>", "<c-d>zz", { desc = "Half page down (centered) " })
 vim.keymap.set("n", "<c-u>", "<c-u>zz", { desc = "Half page up (centered)" })
 
 -- Splitting & Resizing
-vim.keymap.set("n", "<leader>sv", "<cmd>vsplit<cr>", { desc = "Split window vertically", silent = true })
-vim.keymap.set("n", "<leader>sh", "<cmd>split<cr>", { desc = "Split window horizontally", silent = true })
+vim.keymap.set("n", "<leader>|", "<cmd>vsplit<cr>", { desc = "Split window vertically", silent = true })
+vim.keymap.set("n", "<leader>-", "<cmd>split<cr>", { desc = "Split window horizontally", silent = true })
 vim.keymap.set("n", "<c-up>", "<cmd>resize +2<cr>", { desc = "Increase window height", silent = true })
 vim.keymap.set("n", "<c-down>", "<cmd>resize -2<cr>", { desc = "Decrease window height", silent = true })
 vim.keymap.set("n", "<c-left>", "<cmd>vertical resize -2<cr>", { desc = "Decrease window width", silent = true })

--- a/nvim/.config/nvim/lua/config/options.lua
+++ b/nvim/.config/nvim/lua/config/options.lua
@@ -3,7 +3,6 @@ vim.opt.tabstop = 2
 vim.opt.shiftwidth = 2
 vim.opt.softtabstop = 2
 vim.opt.expandtab = true
-vim.opt.smartindent = true
 vim.opt.autoindent = true
 vim.opt.breakindent = true
 vim.opt.showbreak = "> "

--- a/nvim/.config/nvim/lua/plugins/catppuccin.lua
+++ b/nvim/.config/nvim/lua/plugins/catppuccin.lua
@@ -23,7 +23,6 @@ return {
       blink_cmp = { style = "bordered" },
       dap = true,
       dap_ui = true,
-      diffview = true,
       gitsigns = true,
       native_lsp = {
         enabled = true,

--- a/nvim/.config/nvim/lua/plugins/cmp.lua
+++ b/nvim/.config/nvim/lua/plugins/cmp.lua
@@ -40,7 +40,6 @@ return {
     },
 
     appearance = {
-      use_nvim_cmp_as_default = true,
       nerd_font_variant = "mono",
     },
 

--- a/nvim/.config/nvim/lua/plugins/dap/adapters.lua
+++ b/nvim/.config/nvim/lua/plugins/dap/adapters.lua
@@ -1,17 +1,29 @@
 -- More dap adapters can be found at:
 -- https://codeberg.org/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation
 local dap = require("dap")
+local system = require("config.system")
 
 dap.adapters.codelldb = {
   type = "executable",
   command = "codelldb",
 }
 
-dap.adapters.bashdb = {
-  type = "executable",
-  command = vim.fn.stdpath("data") .. "/mason/packages/bash-debug-adapter/bash-debug-adapter",
-  name = "bashdb",
-}
+-- On Nix systems Mason is disabled; expect bash-debug-adapter on $PATH
+-- (e.g. installed via a Nix devShell or home-manager package).
+-- On non-Nix systems Mason provides the adapter under its data directory.
+if system.is_nix() then
+  dap.adapters.bashdb = {
+    type = "executable",
+    command = vim.fn.exepath("bash-debug-adapter"),
+    name = "bashdb",
+  }
+else
+  dap.adapters.bashdb = {
+    type = "executable",
+    command = vim.fn.stdpath("data") .. "/mason/packages/bash-debug-adapter/bash-debug-adapter",
+    name = "bashdb",
+  }
+end
 
 dap.adapters.python = function(cb, config)
   if config.request == "attach" then

--- a/nvim/.config/nvim/lua/plugins/dap/configurations.lua
+++ b/nvim/.config/nvim/lua/plugins/dap/configurations.lua
@@ -1,6 +1,7 @@
 -- More dap configurations can be found at:
 -- https://codeberg.org/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation
 local dap = require("dap")
+local system = require("config.system")
 
 dap.configurations.rust = {
   {
@@ -43,8 +44,13 @@ dap.configurations.sh = {
     request = "launch",
     name = "Launch file",
     showDebugOutput = true,
-    pathBashdb = vim.fn.stdpath("data") .. "/mason/packages/bash-debug-adapter/extension/bashdb_dir/bashdb",
-    pathBashdbLib = vim.fn.stdpath("data") .. "/mason/packages/bash-debug-adapter/extension/bashdb_dir",
+    -- On Nix, bashdb is expected on $PATH; on non-Nix it lives under the Mason package.
+    pathBashdb = system.is_nix()
+      and (vim.fn.exepath("bashdb") ~= "" and vim.fn.exepath("bashdb") or "bashdb")
+      or vim.fn.stdpath("data") .. "/mason/packages/bash-debug-adapter/extension/bashdb_dir/bashdb",
+    pathBashdbLib = system.is_nix()
+      and (vim.fn.exepath("bashdb") ~= "" and vim.fn.fnamemodify(vim.fn.exepath("bashdb"), ":h") or "")
+      or vim.fn.stdpath("data") .. "/mason/packages/bash-debug-adapter/extension/bashdb_dir",
     trace = true,
     file = "${file}",
     program = "${file}",

--- a/nvim/.config/nvim/lua/plugins/neogit.lua
+++ b/nvim/.config/nvim/lua/plugins/neogit.lua
@@ -5,6 +5,22 @@ return {
     {
       "esmuellert/codediff.nvim",
       cmd = "CodeDiff",
+      init = function()
+        -- Track the tabpage opened by CodeDiff so the keybind can toggle it.
+        -- These autocmds are registered immediately (init runs before lazy-load).
+        vim.api.nvim_create_autocmd("User", {
+          pattern = "CodeDiffOpen",
+          callback = function(ev)
+            vim.g.codediff_open_tabpage = ev.data and ev.data.tabpage
+          end,
+        })
+        vim.api.nvim_create_autocmd("User", {
+          pattern = "CodeDiffClose",
+          callback = function()
+            vim.g.codediff_open_tabpage = nil
+          end,
+        })
+      end,
     },
     "folke/snacks.nvim",
   },
@@ -29,15 +45,16 @@ return {
     {
       "<leader>gd",
       function()
-        if require("diffview.lib").get_current_view() then
-          -- Current tabpage is a Diffview; close it
-          vim.cmd.DiffviewClose()
+        local tabpage = vim.g.codediff_open_tabpage
+        if tabpage and vim.api.nvim_tabpage_is_valid(tabpage) then
+          -- CodeDiff is open; close that tab
+          vim.cmd("tabclose " .. vim.api.nvim_tabpage_get_number(tabpage))
         else
-          -- No open Diffview exists: open a new one
-          vim.cmd.DiffviewOpen()
+          -- No open CodeDiff view: open one
+          vim.cmd.CodeDiff()
         end
       end,
-      desc = "Git Diff",
+      desc = "Git Diff (toggle)",
     },
   },
 }

--- a/nvim/.config/nvim/lua/plugins/render-markdown.lua
+++ b/nvim/.config/nvim/lua/plugins/render-markdown.lua
@@ -2,9 +2,9 @@ return {
   "MeanderingProgrammer/render-markdown.nvim",
   dependencies = { "nvim-treesitter/nvim-treesitter", "nvim-mini/mini.icons" },
   version = "*",
-  ft = { "markdown", "Avante" },
+  ft = { "markdown" },
   opts = {
-    file_types = { "markdown", "Avante" },
+    file_types = { "markdown" },
     completions = { blink = { enabled = true } },
   },
 }

--- a/nvim/.config/nvim/lua/plugins/whichkey.lua
+++ b/nvim/.config/nvim/lua/plugins/whichkey.lua
@@ -2,5 +2,5 @@ return {
   "folke/which-key.nvim",
   version = "*",
   event = "VeryLazy",
-  opt = {},
+  opts = {},
 }


### PR DESCRIPTION
## Summary

Fixes all issues identified during a plugin config review.

### Bug fixes

- **`neogit.lua`** — `<leader>gd` was calling `require("diffview.lib")` and `:DiffviewOpen`/`:DiffviewClose` which belong to `sindrets/diffview.nvim` (not installed). Rewritten to use `codediff.nvim`'s `:CodeDiff` command with a proper open/close toggle: the `CodeDiffOpen`/`CodeDiffClose` user autocmds track the active tabpage handle, and the keybind calls `:tabclose` when that tab is valid.
- **`catppuccin.lua`** — Removed dead `diffview = true` integration (no-op without `sindrets/diffview.nvim`).
- **`whichkey.lua`** — Fixed `opt = {}` typo → `opts = {}`. `opt` is not a valid lazy.nvim spec key, so `setup()` was never being called automatically.
- **`keybinds.lua`** — Resolved keybind conflict: `<leader>sh` was mapped to both "Split window horizontally" (keybinds.lua) and "Search help" (snacks picker). The snacks mapping was silently winning. Horizontal split moved to `<leader>-`.

### Nix fix

- **`dap/adapters.lua` + `dap/configurations.lua`** — Bash DAP adapter hardcoded Mason paths that don't exist on Nix systems. Added `is_nix()` guard (matching the pattern in `lsp.lua`): on Nix, `exepath("bash-debug-adapter")` / `exepath("bashdb")` are used instead.

### Cleanup

- **`cmp.lua`** — Removed deprecated `use_nvim_cmp_as_default = true` (blink.cmp docs say it will be removed; catppuccin's `blink_cmp` integration handles theming).
- **`render-markdown.lua`** — Removed `"Avante"` filetype entries (Avante plugin not installed).
- **`options.lua`** — Removed `vim.opt.smartindent` (marked obsolete in Neovim; superseded by treesitter `indentexpr` and filetype indent).