### PR TITLE
✨ feat(nix): add AI tools — github-copilot-cli, docker-sbx, kvm group

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,15 @@
 
       lib = inputs.nixpkgs.lib;
 
+      # lib.getName returns the pname of a derivation. Strings here must match pname
+      # exactly — a rename in nix/pkgs/docker-sbx.nix will silently break unfree access.
+      allowUnfreePredicate =
+        pkg:
+        builtins.elem (lib.getName pkg) [
+          "github-copilot-cli"
+          "docker-sbx" # pname in nix/pkgs/docker-sbx.nix
+        ];
+
       overlays = [
         (final: prev: {
           xdg-user-dirs = prev.xdg-user-dirs.overrideAttrs (old: rec {
@@ -50,6 +59,8 @@
                 --replace-fail "X-systemd-skip=true" "X-systemd-skip=false"
             '';
           });
+
+          docker-sbx = final.callPackage ./nix/pkgs/docker-sbx.nix { };
         })
       ];
 
@@ -61,6 +72,7 @@
             {
               networking.hostName = host;
               nixpkgs.overlays = overlays;
+              nixpkgs.config.allowUnfreePredicate = allowUnfreePredicate;
             }
             ./nix/hosts/${host}
             inputs.home-manager.nixosModules.home-manager
@@ -89,6 +101,10 @@
           pkgs = import inputs.nixpkgs {
             system = hostSystem;
             inherit overlays;
+            # config here applies only to standalone homeConfigurations.
+            # For NixOS-managed users, useGlobalPkgs = true means NixOS pkgs are used,
+            # and the unfree predicate is applied via nixpkgs.config in mkSystem instead.
+            config = { inherit allowUnfreePredicate; };
           };
           modules = [ ./nix/home ];
           extraSpecialArgs = { inherit wsl; };

--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -44,6 +44,7 @@ in
         fd
         gcc
         gh
+        github-copilot-cli
         gnumake
         python3
         ripgrep
@@ -93,6 +94,10 @@ in
         delve
         python3Packages.debugpy
         vscode-extensions.vadimcn.vscode-lldb # codelldb
+      ]
+      ++ lib.optionals (pkgs.stdenv.hostPlatform.system == "x86_64-linux") [
+        # docker-sbx is only published for x86_64-linux; no aarch64 release.
+        pkgs.docker-sbx
       ]
       # gnupg is provided system-wide on NixOS via the gnupg common module;
       # only add it here for standalone Home Manager (non-NixOS).

--- a/nix/modules/common/users.nix
+++ b/nix/modules/common/users.nix
@@ -2,7 +2,10 @@
 {
   users.users.dandyrow = {
     isNormalUser = true;
-    extraGroups = [ "wheel" ];
+    extraGroups = [
+      "wheel"
+      "kvm"
+    ];
     shell = pkgs.zsh;
     # Hash is injected at install time via nixos-anywhere --extra-files.
     # Never committed in plaintext — see README for the install procedure.

--- a/nix/pkgs/docker-sbx.nix
+++ b/nix/pkgs/docker-sbx.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  makeWrapper,
+  patchelf,
+  e2fsprogs,
+  lz4,
+  xxhash,
+  zlib,
+  zstd,
+}:
+
+let
+  version = "0.30.0";
+  sharedLibs = lib.makeLibraryPath [
+    stdenv.cc.cc.lib
+    lz4
+    xxhash
+    zlib
+    zstd
+  ];
+in
+stdenv.mkDerivation {
+  pname = "docker-sbx";
+  inherit version;
+
+  src = fetchzip {
+    url = "https://github.com/docker/sbx-releases/releases/download/v${version}/DockerSandboxes-linux.tar.gz";
+    hash = "sha256-uO4HM+iCm4OHe727y0PVzzhV77LP7UG4MuCX6Tn9hBU=";
+    stripRoot = true;
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    patchelf
+  ];
+
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin" "$out/libexec/lib" "$out/share/doc/docker-sbx"
+
+    install -m755 "$src/sbx"                             "$out/bin/sbx"
+    install -m755 "$src/containerd-shim-nerdbox-v1"      "$out/libexec/containerd-shim-nerdbox-v1"
+    install -m755 "$src/mkfs.erofs"                      "$out/libexec/mkfs.erofs"
+    install -m755 "$src/libsailor.so"                    "$out/libexec/lib/libsailor.so"
+    install -m644 "$src"/nerdbox-kernel-*                "$out/libexec/"
+    install -m644 "$src"/nerdbox-initrd-*                "$out/libexec/"
+
+    if [ -f "$src/LICENSE" ]; then
+      install -m644 "$src/LICENSE" "$out/share/doc/docker-sbx/LICENSE"
+    fi
+    if [ -f "$src/THIRD-PARTY-NOTICES" ]; then
+      install -m644 "$src/THIRD-PARTY-NOTICES" "$out/share/doc/docker-sbx/THIRD-PARTY-NOTICES"
+    fi
+    if [ -f "$src/apparmor-profile" ]; then
+      install -m644 "$src/apparmor-profile" "$out/libexec/apparmor-profile"
+    fi
+
+    patchelf --set-rpath "${sharedLibs}" "$out/libexec/mkfs.erofs"
+    patchelf --set-rpath "${sharedLibs}" "$out/libexec/containerd-shim-nerdbox-v1"
+    patchelf --set-rpath "${sharedLibs}:$out/libexec/lib" "$out/libexec/lib/libsailor.so"
+
+    wrapProgram "$out/bin/sbx" \
+      --set LIBKRUN_PATH "$out/libexec" \
+      --prefix PATH : "${lib.makeBinPath [ e2fsprogs ]}"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Docker Sandboxes CLI — safe microVM environments for AI agents";
+    homepage = "https://github.com/docker/sbx-releases";
+    license = licenses.unfreeRedistributable;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "sbx";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
## Summary

- **`nix/pkgs/docker-sbx.nix`**: Custom derivation for [Docker Sandboxes](https://github.com/docker/sbx-releases) v0.30.0. Wraps the pre-built binary with `libsailor.so` (renamed from `libkrun` in v0.30.0), `LIBKRUN_PATH` env var, and correct rpath. Only available for `x86_64-linux`.
- **`flake.nix`**: Adds `docker-sbx` to the package overlay; adds `allowUnfreePredicate` to permit `github-copilot-cli` (unfree) scoped to exactly those packages that require it.
- **`nix/home/default.nix`**: Adds `github-copilot-cli` (all platforms) and `docker-sbx` (x86_64-linux only, guarded via `lib.optionals`) to `home.packages`.
- **`nix/modules/common/users.nix`**: Adds `"kvm"` to `dandyrow`'s `extraGroups` to support nested virtualisation (required by docker-sbx / WSL Hyper-V).

## Verification

- `docker-sbx` built and `sbx version` confirmed `v0.30.0` output.
- `homeConfigurations."dandyrow@x86_64-linux"` and `homeConfigurations."dandyrow@wsl"` built successfully.
- `homeConfigurations."dandyrow@aarch64-linux"` timed out in CI (QEMU emulation) but is structurally identical to x86_64 minus the docker-sbx guard — expected to succeed.

## Post-deploy steps (manual, out of scope)

- WSL: enable nested virtualisation in Hyper-V settings
- Run `sbx login` on each host