### PR TITLE
🐛 fix(docker-sbx): add libexec to PATH so mkfs.erofs is found at runtime

### DIFF
--- a/nix/pkgs/docker-sbx.nix
+++ b/nix/pkgs/docker-sbx.nix
@@ -64,9 +64,12 @@ stdenv.mkDerivation {
     patchelf --set-rpath "${sharedLibs}" "$out/libexec/containerd-shim-nerdbox-v1"
     patchelf --set-rpath "${sharedLibs}:$out/libexec/lib" "$out/libexec/lib/libsailor.so"
 
+    # $out/libexec must be on PATH so sandboxd can find mkfs.erofs and
+    # containerd-shim-nerdbox-v1 at runtime; without it the erofs differ
+    # plugin fails with exit status 127 and the entire daemon fails to start.
     wrapProgram "$out/bin/sbx" \
       --set LIBKRUN_PATH "$out/libexec" \
-      --prefix PATH : "${lib.makeBinPath [ e2fsprogs ]}"
+      --prefix PATH : "$out/libexec:${lib.makeBinPath [ e2fsprogs ]}"
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Root Cause

When `sandboxd` starts, the embedded containerd checks for `mkfs.erofs` availability by running `mkfs.erofs --help`. This binary is installed to `$out/libexec/` but that directory was not added to `PATH` in the `wrapProgram` call — only `e2fsprogs` was. The result was `exit status 127` (command not found), which caused the erofs differ plugin to skip itself, which cascaded into `io.containerd.transfer.v1.local` skipping itself (it requires the erofs differ), which left the transfer plugin registry empty, killing the daemon.

Diagnosed from `/home/dandyrow/.local/state/sandboxes/sandboxes/sandboxd/daemon.log`:
```
"skip loading plugin","id":"io.containerd.differ.v1.erofs",
"error":"failed to check mkfs.erofs availability: failed to run mkfs.erofs --help: exit status 127: skip plugin"
```

## Fix

Add `$out/libexec` to `PATH` in the `wrapProgram` call. This also ensures `containerd-shim-nerdbox-v1` (also in `libexec`) is discoverable by containerd at runtime.

## Verification

Rebuilt `docker-sbx-0.30.0`; wrapper script confirmed to prepend both `$out/libexec` and `e2fsprogs/bin` to `PATH`.