### PR TITLE
🐛 fix(docker-sbx): patch ELF interpreter for mkfs.erofs and containerd shim

### DIFF
--- a/nix/pkgs/docker-sbx.nix
+++ b/nix/pkgs/docker-sbx.nix
@@ -60,8 +60,24 @@ stdenv.mkDerivation {
       install -m644 "$src/apparmor-profile" "$out/libexec/apparmor-profile"
     fi
 
-    patchelf --set-rpath "${sharedLibs}" "$out/libexec/mkfs.erofs"
-    patchelf --set-rpath "${sharedLibs}" "$out/libexec/containerd-shim-nerdbox-v1"
+    # Both executables were built for a generic Linux environment and carry
+    # /lib64/ld-linux-x86-64.so.2 as their ELF interpreter.  On NixOS that
+    # path is a stub that prints "cannot run dynamically linked executable",
+    # so we must patch the interpreter to the Nix-store glibc loader as well
+    # as the rpath for shared-library resolution.
+    local interp
+    interp="$(cat "${stdenv.cc}/nix-support/dynamic-linker")"
+
+    patchelf \
+      --set-interpreter "$interp" \
+      --set-rpath "${sharedLibs}" \
+      "$out/libexec/mkfs.erofs"
+    patchelf \
+      --set-interpreter "$interp" \
+      --set-rpath "${sharedLibs}" \
+      "$out/libexec/containerd-shim-nerdbox-v1"
+    # libsailor.so is a shared library (no interpreter needed); extend its
+    # rpath so it can resolve its own bundled dependencies.
     patchelf --set-rpath "${sharedLibs}:$out/libexec/lib" "$out/libexec/lib/libsailor.so"
 
     # $out/libexec must be on PATH so sandboxd can find mkfs.erofs and

--- a/nix/pkgs/docker-sbx.nix
+++ b/nix/pkgs/docker-sbx.nix
@@ -64,9 +64,12 @@ stdenv.mkDerivation {
     patchelf --set-rpath "${sharedLibs}" "$out/libexec/containerd-shim-nerdbox-v1"
     patchelf --set-rpath "${sharedLibs}:$out/libexec/lib" "$out/libexec/lib/libsailor.so"
 
+    # $out/libexec must be on PATH so sandboxd can find mkfs.erofs and
+    # containerd-shim-nerdbox-v1 at runtime; without it the erofs differ
+    # plugin fails with exit status 127 and the entire daemon fails to start.
     wrapProgram "$out/bin/sbx" \
       --set LIBKRUN_PATH "$out/libexec" \
-      --prefix PATH : "${lib.makeBinPath [ e2fsprogs ]}"
+      --prefix PATH : "$out/libexec:${lib.makeBinPath [ e2fsprogs ]}"
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Root Cause

PR #22 fixed `mkfs.erofs` not being on `PATH`, but the binary still could not execute. Both `mkfs.erofs` and `containerd-shim-nerdbox-v1` carry `/lib64/ld-linux-x86-64.so.2` as their ELF interpreter. On NixOS that path is a stub that prints:

```
NixOS cannot run dynamically linked executables intended for generic linux environments out of the box.
```

Previous fix only called `patchelf --set-rpath` but not `--set-interpreter`, so `exit status 127` persisted despite the PATH fix.

## Fix

Add `--set-interpreter "$(cat "${stdenv.cc}/nix-support/dynamic-linker")"` to the `patchelf` calls for both executables. The shared library `libsailor.so` is unaffected (shared libs have no interpreter entry).

## Verification

After this fix:
- ELF interpreter → `/nix/store/.../glibc-2.42-61/lib/ld-linux-x86-64.so.2`
- `mkfs.erofs --help` → exit 0, prints usage
- `containerd-shim-nerdbox-v1 --help` → exit 0