### PR TITLE
🐛 fix(wsl): grant dandyrow access to loop devices for sbx erofs mounts

### DIFF
--- a/nix/hosts/WSL/configuration.nix
+++ b/nix/hosts/WSL/configuration.nix
@@ -27,5 +27,14 @@
     /etc/nixos/corp.pem
   ];
 
+  # In WSL, loop devices (/dev/loop-control, /dev/loop*) are initialised by
+  # the WSL kernel with GID 995, which has no named entry in /etc/group by
+  # default.  Define a named group for that GID and add dandyrow to it so sbx
+  # (docker-sbx) can open loop devices when mounting erofs sandbox images.
+  users.groups.loop = {
+    gid = 995;
+  };
+  users.users.dandyrow.extraGroups = [ "loop" ];
+
   system.stateVersion = "25.11";
 }


### PR DESCRIPTION
## Summary

- Defines a named NixOS group `loop` at GID 995 in the WSL host config
- Adds `dandyrow` to that group via `users.users.dandyrow.extraGroups`

## Root Cause

`/dev/loop-control` and `/dev/loop*` in WSL are created by the WSL kernel with GID 995, which has no corresponding named group in `/etc/group`. The devices have mode `0660`, so only root and group members can open them. `sbx` (`docker-sbx`) needs to open `/dev/loop-control` to mount erofs sandbox images, and was failing with:

```
mount failed {ext4 ... [rw loop noinit_itable]}: could not open /dev/loop-control: open /dev/loop-control: permission denied
```

## Why WSL-specific

GID 995 is assigned by the WSL kernel's device initialisation and is not present on other hosts. Defining the group and group membership here rather than in the common users module avoids a GID conflict on DansSpectre and New-H0Ryzen.