### PR TITLE
🐛 fix(wsl): run sbx daemon as system service with CAP_SYS_ADMIN

### DIFF
--- a/nix/hosts/WSL/configuration.nix
+++ b/nix/hosts/WSL/configuration.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 {
   wsl = {
     enable = true;
@@ -35,6 +35,26 @@
     gid = 995;
   };
   users.users.dandyrow.extraGroups = [ "loop" ];
+
+  # sbx (Docker Sandboxes) daemon requires CAP_SYS_ADMIN to mount loop devices
+  # for erofs sandbox images.  A user service cannot self-elevate capabilities,
+  # so we run a system-level service as dandyrow and grant CAP_SYS_ADMIN via
+  # AmbientCapabilities so the capability is inherited by the daemon process.
+  systemd.services.sbx-daemon = {
+    description = "Docker Sandboxes daemon (sbx)";
+    wantedBy = [ "multi-user.target" ];
+    after = [ "network.target" ];
+    serviceConfig = {
+      Type = "forking";
+      User = "dandyrow";
+      ExecStart = "${pkgs.docker-sbx}/bin/sbx daemon start";
+      ExecStop = "${pkgs.docker-sbx}/bin/sbx daemon stop";
+      AmbientCapabilities = "CAP_SYS_ADMIN";
+      CapabilityBoundingSet = "CAP_SYS_ADMIN";
+      Restart = "on-failure";
+      RestartSec = "5s";
+    };
+  };
 
   system.stateVersion = "25.11";
 }


### PR DESCRIPTION
## Summary

- Adds a `systemd.services.sbx-daemon` system-level service to the WSL host config
- Runs the daemon as `dandyrow` with `AmbientCapabilities = CAP_SYS_ADMIN`
- Adds `pkgs` to the WSL module arguments to reference `pkgs.docker-sbx`

## Root Cause

After the loop-device group fix (PR #25), the daemon could open `/dev/loop-control` but still failed mounting the loop device as ext4:

```
mount source: "/dev/loop0", ..., err: operation not permitted
```

The sbx daemon process had zero effective capabilities (`CapEff: 0000000000000000`). Mounting loop devices requires `CAP_SYS_ADMIN`.

## Why a system service

A systemd **user** service cannot self-elevate capabilities — it can only use capabilities already in the user's permitted set (none for a regular user). A **system-level** service running as `dandyrow` with `AmbientCapabilities = CAP_SYS_ADMIN` has the capability granted by systemd at service start, and the daemon process inherits it.

## After merge

1. `nixos-rebuild switch`
2. `systemctl start sbx-daemon` (or reboot — it's `wantedBy = multi-user.target`)
3. Run `sbx` — it will connect to the already-running privileged daemon rather than launching its own unprivileged one