### PR TITLE
🐛 fix(wsl): correct sbx-daemon service type to simple (foreground process)

### DIFF
--- a/nix/hosts/WSL/configuration.nix
+++ b/nix/hosts/WSL/configuration.nix
@@ -45,7 +45,7 @@
     wantedBy = [ "multi-user.target" ];
     after = [ "network.target" ];
     serviceConfig = {
-      Type = "forking";
+      Type = "simple";
       User = "dandyrow";
       ExecStart = "${pkgs.docker-sbx}/bin/sbx daemon start";
       ExecStop = "${pkgs.docker-sbx}/bin/sbx daemon stop";


### PR DESCRIPTION
## Summary

- Changes `systemd.services.sbx-daemon.serviceConfig.Type` from `"forking"` to `"simple"`

## Root Cause

`sbx daemon start` runs in the **foreground** (it prints `Starting daemon at ... (Ctrl+C to stop)...` and keeps running). With `Type = "forking"`, systemd waits for the process to fork and the parent to exit — which never happens. The service was stuck in `activating (start)` indefinitely.

With `Type = "simple"`, systemd tracks the foreground process directly as the main service process.