### PR TITLE
🐛 fix(nix/wsl): grant dandyrow disk group for sbx loop-device access

### DIFF
--- a/nix/hosts/WSL/configuration.nix
+++ b/nix/hosts/WSL/configuration.nix
@@ -27,12 +27,9 @@
     /etc/nixos/corp.pem
   ];
 
-  # In WSL, /dev/loop-control and /dev/loop* are created by the WSL kernel
-  # owned by root:disk with mode 0660.  sbx (docker-sbx) needs to open
-  # /dev/loop-control to allocate a loop device when mounting the erofs
-  # sandbox rwlayer.img; opening that node is a normal DAC check that
-  # CAP_SYS_ADMIN does not bypass.  Adding dandyrow to the disk group is the
-  # simplest fix and matches how loop-device access is granted on most distros.
+  # WSL creates /dev/loop-control and /dev/loop* as root:disk 0660.  sbx needs
+  # to open /dev/loop-control to mount its erofs sandbox image, and that DAC
+  # check is not bypassed by CAP_SYS_ADMIN, so dandyrow must be in disk.
   users.users.dandyrow.extraGroups = [ "disk" ];
 
   # sbx (Docker Sandboxes) daemon requires CAP_SYS_ADMIN to call mount() for

--- a/nix/hosts/WSL/configuration.nix
+++ b/nix/hosts/WSL/configuration.nix
@@ -27,17 +27,16 @@
     /etc/nixos/corp.pem
   ];
 
-  # In WSL, loop devices (/dev/loop-control, /dev/loop*) are initialised by
-  # the WSL kernel with GID 995, which has no named entry in /etc/group by
-  # default.  Define a named group for that GID and add dandyrow to it so sbx
-  # (docker-sbx) can open loop devices when mounting erofs sandbox images.
-  users.groups.loop = {
-    gid = 995;
-  };
-  users.users.dandyrow.extraGroups = [ "loop" ];
+  # In WSL, /dev/loop-control and /dev/loop* are created by the WSL kernel
+  # owned by root:disk with mode 0660.  sbx (docker-sbx) needs to open
+  # /dev/loop-control to allocate a loop device when mounting the erofs
+  # sandbox rwlayer.img; opening that node is a normal DAC check that
+  # CAP_SYS_ADMIN does not bypass.  Adding dandyrow to the disk group is the
+  # simplest fix and matches how loop-device access is granted on most distros.
+  users.users.dandyrow.extraGroups = [ "disk" ];
 
-  # sbx (Docker Sandboxes) daemon requires CAP_SYS_ADMIN to mount loop devices
-  # for erofs sandbox images.  A user service cannot self-elevate capabilities,
+  # sbx (Docker Sandboxes) daemon requires CAP_SYS_ADMIN to call mount() for
+  # erofs sandbox images.  A user service cannot self-elevate capabilities,
   # so we run a system-level service as dandyrow and grant CAP_SYS_ADMIN via
   # AmbientCapabilities so the capability is inherited by the daemon process.
   systemd.services.sbx-daemon = {


### PR DESCRIPTION
## Summary

Fix `sbx run` failing on WSL with `could not open /dev/loop-control: permission denied` by adding `dandyrow` to the `disk` group and removing the ineffective `loop` group workaround.

## Root cause

The previous attempt assumed the WSL kernel created `/dev/loop-control` with GID 995 and no named group, so it declared a `loop` group at GID 995 and added `dandyrow` to it. In reality:

- WSL creates `/dev/loop-control` and `/dev/loop*` as `root:disk` (GID 6) mode `0660`
- `dandyrow` was not in `disk`, so opening the node was DAC-denied
- `CAP_SYS_ADMIN` on the `sbx-daemon` service was necessary for `mount()` but does **not** bypass file DAC checks on `/dev/loop-control`

Verified on the host:

```
$ stat -c '%n %U:%G %a' /dev/loop-control
/dev/loop-control root:disk 660
$ id
... groups=...,302(kvm),995(loop)   # no disk
```

## Change

- Drop `users.groups.loop = { gid = 995; }` and the `loop` entry from `extraGroups`
- Add `disk` to `users.users.dandyrow.extraGroups`
- Rewrite the comment to reflect the actual cause (DAC vs `CAP_SYS_ADMIN`)
- Keep `CAP_SYS_ADMIN` on `sbx-daemon` (still required for the `mount()` syscall)

## Verification

- `nix eval .#nixosConfigurations.WSL.config.users.users.dandyrow.extraGroups` returns `["disk","wheel","kvm","wheel"]`
- Post-rebuild verification (manual, after `nixos-rebuild switch` + WSL session restart):
  - `id | grep disk` shows membership
  - `sbx run copilot` no longer fails on `/dev/loop-control`

## Notes

WSL2 is not officially supported by Docker `sbx` (docs list Ubuntu 24.04+ only). Further microVM/KVM-related errors may surface after this fix; those are out of scope for this PR.