### PR TITLE
🐛 fix(nix/wsl,docker-sbx): use nix-ld instead of patchelf for sbx shim

### DIFF
--- a/nix/hosts/WSL/configuration.nix
+++ b/nix/hosts/WSL/configuration.nix
@@ -27,15 +27,28 @@
     /etc/nixos/corp.pem
   ];
 
-  # WSL creates /dev/loop-control and /dev/loop* as root:disk 0660.  sbx needs
-  # to open /dev/loop-control to mount its erofs sandbox image, and that DAC
-  # check is not bypassed by CAP_SYS_ADMIN, so dandyrow must be in disk.
-  users.users.dandyrow.extraGroups = [ "disk" ];
+  # Enable nix-ld so the docker-sbx containerd shim (a Go cgo binary) and
+  # mkfs.erofs can resolve /lib64/ld-linux-x86-64.so.2 at runtime.  This
+  # replaces a previous attempt to patchelf --set-interpreter on the shim,
+  # which corrupts Go binaries: extending PT_INTERP shifts PT_LOAD offsets
+  # and Go's runtime hard-codes layout assumptions, causing SIGSEGV at the
+  # entry point.  nix-ld is the canonical NixOS way to run unmodified
+  # foreign Linux binaries.
+  programs.nix-ld = {
+    enable = true;
+    libraries = with pkgs; [
+      stdenv.cc.cc.lib
+      lz4
+      xxhash
+      zlib
+      zstd
+    ];
+  };
 
-  # sbx (Docker Sandboxes) daemon requires CAP_SYS_ADMIN to call mount() for
-  # erofs sandbox images.  A user service cannot self-elevate capabilities,
-  # so we run a system-level service as dandyrow and grant CAP_SYS_ADMIN via
-  # AmbientCapabilities so the capability is inherited by the daemon process.
+  # sbx daemon as a user-scoped system service.  No CAP_SYS_ADMIN and no
+  # disk group: verified against a working Ubuntu/WSL2 install (sbx 0.30.0)
+  # where the daemon runs with CapEff=0 and is not in the disk group, so
+  # the mount/loop operations needed by sbx do not require either.
   systemd.services.sbx-daemon = {
     description = "Docker Sandboxes daemon (sbx)";
     wantedBy = [ "multi-user.target" ];
@@ -45,8 +58,6 @@
       User = "dandyrow";
       ExecStart = "${pkgs.docker-sbx}/bin/sbx daemon start";
       ExecStop = "${pkgs.docker-sbx}/bin/sbx daemon stop";
-      AmbientCapabilities = "CAP_SYS_ADMIN";
-      CapabilityBoundingSet = "CAP_SYS_ADMIN";
       Restart = "on-failure";
       RestartSec = "5s";
     };

--- a/nix/hosts/WSL/configuration.nix
+++ b/nix/hosts/WSL/configuration.nix
@@ -4,36 +4,25 @@
     enable = true;
     defaultUser = "dandyrow";
 
-    # Enable systemd under WSL2 (requires Windows 11 / WSL 0.67.6+)
-    # See: https://devblogs.microsoft.com/commandline/systemd-support-is-now-available-in-wsl/
+    # Enable systemd under WSL2 (requires Windows 11 / WSL 0.67.6+).
     useWindowsDriver = true;
   };
 
-  # Disable systemd-boot — WSL provides its own boot path and the nixos-wsl
-  # module sets installBootLoader to a no-op, which conflicts with the
-  # systemd-boot module enabled by default in common/systemd-boot.nix.
+  # WSL provides its own boot path; conflicts with common/systemd-boot.nix.
   systemd-boot.enable = false;
 
   documentation.nixos.enable = false;
 
   programs.git.enable = true;
 
-  # Include the corporate CA certificate if present at /etc/nixos/corp.pem.
-  # This file must be placed there manually and is never committed to git.
-  # Requires --impure flag when running nixos-rebuild.
-  # The builtins.pathExists guard means this evaluates safely to [] when the
-  # file is absent (e.g. on non-WSL machines without the cert).
+  # Corporate CA cert, manually placed at /etc/nixos/corp.pem (never committed).
+  # Requires --impure; evaluates to [] when absent.
   security.pki.certificateFiles = lib.optionals (builtins.pathExists /etc/nixos/corp.pem) [
     /etc/nixos/corp.pem
   ];
 
-  # Enable nix-ld so the docker-sbx containerd shim (a Go cgo binary) and
-  # mkfs.erofs can resolve /lib64/ld-linux-x86-64.so.2 at runtime.  This
-  # replaces a previous attempt to patchelf --set-interpreter on the shim,
-  # which corrupts Go binaries: extending PT_INTERP shifts PT_LOAD offsets
-  # and Go's runtime hard-codes layout assumptions, causing SIGSEGV at the
-  # entry point.  nix-ld is the canonical NixOS way to run unmodified
-  # foreign Linux binaries.
+  # Lets docker-sbx's Go cgo shim and mkfs.erofs resolve /lib64/ld-linux at
+  # runtime, avoiding patchelf (which corrupts Go binaries' PT_LOAD layout).
   programs.nix-ld = {
     enable = true;
     libraries = with pkgs; [
@@ -45,10 +34,8 @@
     ];
   };
 
-  # sbx daemon as a user-scoped system service.  No CAP_SYS_ADMIN and no
-  # disk group: verified against a working Ubuntu/WSL2 install (sbx 0.30.0)
-  # where the daemon runs with CapEff=0 and is not in the disk group, so
-  # the mount/loop operations needed by sbx do not require either.
+  # sbx daemon as a user-scoped system service. No CAP_SYS_ADMIN / disk group:
+  # the working Ubuntu/WSL2 install runs sbx 0.30.0 without either.
   systemd.services.sbx-daemon = {
     description = "Docker Sandboxes daemon (sbx)";
     wantedBy = [ "multi-user.target" ];

--- a/nix/pkgs/docker-sbx.nix
+++ b/nix/pkgs/docker-sbx.nix
@@ -3,49 +3,31 @@
   stdenv,
   fetchzip,
   makeWrapper,
-  patchelf,
   e2fsprogs,
-  lz4,
-  xxhash,
-  zlib,
-  zstd,
 }:
 
-let
-  version = "0.30.0";
-
-  # Libraries dlopened/linked by the upstream binaries (mainly erofs
-  # compression deps). Added defensively so an upstream bump can't silently
-  # break runtime resolution.
-  sharedLibs = lib.makeLibraryPath [
-    stdenv.cc.cc.lib
-    lz4
-    xxhash
-    zlib
-    zstd
-  ];
-in
 stdenv.mkDerivation {
   pname = "docker-sbx";
-  inherit version;
+  version = "0.30.0";
 
   src = fetchzip {
-    url = "https://github.com/docker/sbx-releases/releases/download/v${version}/DockerSandboxes-linux.tar.gz";
+    url = "https://github.com/docker/sbx-releases/releases/download/v0.30.0/DockerSandboxes-linux.tar.gz";
     hash = "sha256-uO4HM+iCm4OHe727y0PVzzhV77LP7UG4MuCX6Tn9hBU=";
     stripRoot = true;
   };
 
-  nativeBuildInputs = [
-    makeWrapper
-    patchelf
-  ];
+  nativeBuildInputs = [ makeWrapper ];
 
   # Prebuilt Go binaries: stripping can invalidate embedded build info.
   dontStrip = true;
 
-  # Disable stdenv's `patchelf --shrink-rpath` fixup. It drops rpath entries
-  # whose dir holds no DT_NEEDED library; libsailor.so is dlopened (cgo), so
-  # the shrink would remove the very entries we add below.
+  # Do not let stdenv patchelf the upstream binaries.  The shim is a Go
+  # binary that uses cgo to dlopen libsailor.so, and patchelf'ing it (in
+  # particular --set-interpreter to a long /nix/store/... path) corrupts
+  # Go's PT_LOAD layout, producing a SIGSEGV at the binary entry point.
+  # Instead the host enables programs.nix-ld so the upstream-baked
+  # /lib64/ld-linux-x86-64.so.2 resolves to a working glibc loader with
+  # the right libraries on its search path.
   dontPatchELF = true;
 
   installPhase = ''
@@ -71,30 +53,6 @@ stdenv.mkDerivation {
     if [ -f "$src/apparmor-profile" ]; then
       install -m644 "$src/apparmor-profile" "$out/libexec/apparmor-profile"
     fi
-
-    # mkfs.erofs and containerd-shim-nerdbox-v1 hardcode the glibc loader at
-    # /lib64/ld-linux-x86-64.so.2, which is a NixOS stub that exits 127. The
-    # daemon then skips the erofs differ, cascading into transfer-plugin
-    # registration failure. Patch interpreter + rpath together so they stay
-    # in sync on every version bump.
-    interp=${stdenv.cc.bintools.dynamicLinker}
-
-    patchelf \
-      --set-interpreter "$interp" \
-      --set-rpath "${sharedLibs}" \
-      "$out/libexec/mkfs.erofs"
-
-    # Shim dlopens libsailor.so via cgo (sailor_config_*, sailor_vm_*); add
-    # libexec/lib to its rpath so resolution doesn't need LD_LIBRARY_PATH.
-    patchelf \
-      --set-interpreter "$interp" \
-      --set-rpath "${sharedLibs}:$out/libexec/lib" \
-      "$out/libexec/containerd-shim-nerdbox-v1"
-
-    # libsailor.so: shared lib, no interpreter. Extend rpath for neighbours.
-    patchelf \
-      --set-rpath "${sharedLibs}:$out/libexec/lib" \
-      "$out/libexec/lib/libsailor.so"
 
     # sbx shells out to mkfs.erofs (bundled) and mkfs.ext4 (e2fsprogs); neither
     # is on the default NixOS PATH, so prepend both.

--- a/nix/pkgs/docker-sbx.nix
+++ b/nix/pkgs/docker-sbx.nix
@@ -6,12 +6,15 @@
   e2fsprogs,
 }:
 
+let
+  version = "0.30.0";
+in
 stdenv.mkDerivation {
   pname = "docker-sbx";
-  version = "0.30.0";
+  inherit version;
 
   src = fetchzip {
-    url = "https://github.com/docker/sbx-releases/releases/download/v0.30.0/DockerSandboxes-linux.tar.gz";
+    url = "https://github.com/docker/sbx-releases/releases/download/v${version}/DockerSandboxes-linux.tar.gz";
     hash = "sha256-uO4HM+iCm4OHe727y0PVzzhV77LP7UG4MuCX6Tn9hBU=";
     stripRoot = true;
   };
@@ -21,13 +24,8 @@ stdenv.mkDerivation {
   # Prebuilt Go binaries: stripping can invalidate embedded build info.
   dontStrip = true;
 
-  # Do not let stdenv patchelf the upstream binaries.  The shim is a Go
-  # binary that uses cgo to dlopen libsailor.so, and patchelf'ing it (in
-  # particular --set-interpreter to a long /nix/store/... path) corrupts
-  # Go's PT_LOAD layout, producing a SIGSEGV at the binary entry point.
-  # Instead the host enables programs.nix-ld so the upstream-baked
-  # /lib64/ld-linux-x86-64.so.2 resolves to a working glibc loader with
-  # the right libraries on its search path.
+  # patchelf'ing the Go cgo shim corrupts its PT_LOAD layout and segfaults
+  # at entry; rely on programs.nix-ld on the host instead.
   dontPatchELF = true;
 
   installPhase = ''


### PR DESCRIPTION
## Summary
- Fix `sbx run` failures on NixOS-WSL2 caused by patchelf corrupting the Go cgo containerd shim
- Switch to `programs.nix-ld` so the upstream-baked `/lib64/ld-linux-x86-64.so.2` resolves at runtime
- Revert the disk group + `CAP_SYS_ADMIN` scaffolding from #29 (not needed; matches working Ubuntu/WSL2 baseline)

## Root cause
`patchelf --set-interpreter` (introduced in 79ee403) on `containerd-shim-nerdbox-v1` shifts the binary's PT_INTERP/PT_LOAD offsets. Go's runtime hard-codes layout assumptions, so the patched shim segfaults at its entry point (SEGV_ACCERR at 0x4002e0, exit 139). Containerd swallows the segfault and falls back to a host-side erofs mount path, which the kernel rejects with `block device required` — the visible symptom we were previously chasing.

Comparison with a working Ubuntu/WSL2 host on the same kernel (6.6.114.1) showed identical erofs/fscache config, `CapEff=0`, no disk group membership, and that erofs mounts happen inside the microVM rather than on the host. Both the capability and the group from #29 were therefore dead weight.

## Changes
- `nix/pkgs/docker-sbx.nix`: drop all patchelf invocations and library inputs; keep `dontPatchELF = true` and `dontStrip = true`; keep `wrapProgram` PATH for bundled `mkfs.erofs` and `e2fsprogs`; hoist version into a let-binding so the release URL stays in sync.
- `nix/hosts/WSL/configuration.nix`: enable `programs.nix-ld` with `stdenv.cc.cc.lib`, `lz4`, `xxhash`, `zlib`, `zstd`; remove `disk` group from the user; remove `AmbientCapabilities`/`CapabilityBoundingSet = "CAP_SYS_ADMIN"` from the sbx-daemon service; tighten surrounding comments.

## Verification
- `nix eval .#nixosConfigurations.WSL.config.system.build.toplevel.drvPath` succeeds.
- New `docker-sbx` derivation builds; shim ELF is byte-identical to upstream (interpreter `/lib64/ld-linux-x86-64.so.2`, empty rpath, size 9466121 vs 9468545 patched).
- Shim runs successfully when invoked through a Nix glibc loader — confirming nix-ld will satisfy it post-rebuild.

End-to-end `sbx run copilot` verification will follow `nixos-rebuild switch` on the WSL host (requires explicit approval per AGENTS.md).