### PR TITLE
📝 docs(agents): add repo map, environment facts, debugging discipline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,16 +27,19 @@ This file is the source of truth for how coding agents must operate in this repo
 # Create worktree + install hooks
 ./scripts/agent-start.sh <branch>
 
-# Work inside the worktree
-cd .worktrees/<branch>
+# Work inside the worktree (slashes in the branch name are flattened to dashes)
+# e.g. branch "fix/foo-bar" → .worktrees/fix-foo-bar
+cd .worktrees/<flattened-branch>
 
 # Push and open PR
 git push -u origin <branch>
 # then open a PR into main via gh or GitHub UI
 
-# Cleanup (from repo root)
-git worktree remove .worktrees/<branch> && git worktree prune
+# Cleanup (from the main checkout, after the PR is merged and origin/<branch> is deleted)
+./scripts/agent-cleanup.sh <branch>
 ```
+
+After a PR is merged, propose running `scripts/agent-cleanup.sh <branch>` from the main checkout. It removes the worktree, prunes worktree metadata, and deletes the local branch in one step. Worktree/branch deletion still requires explicit user approval per the irreversible-actions rule.
 
 ---
 
@@ -112,3 +115,62 @@ Each action on that list must be individually and explicitly requested before ex
 
 ## If uncertain
 Ask a short clarifying question rather than guessing. Follow existing patterns in this repo.
+
+---
+
+## Repo map
+
+| Path | Purpose |
+| --- | --- |
+| `flake.nix` / `flake.lock` | Flake entry. `nixosConfigurations`: `WSL`, `DansSpectre`, `New-H0Ryzen`. |
+| `nix/hosts/<host>/` | Per-host NixOS configuration (entrypoint: `configuration.nix`). |
+| `nix/home/` | Home-manager configuration shared across hosts. |
+| `nix/modules/{common,desktop,profiles}/` | Reusable NixOS modules composed by hosts. |
+| `nix/pkgs/` | Repo-local package derivations (e.g. `docker-sbx.nix`), exposed via `pkgs` overlay. |
+| `scripts/agent-start.sh` | Creates the per-branch worktree and installs the co-author hook. |
+| `scripts/agent-cleanup.sh` | Removes a merged branch's worktree and local branch in one step. |
+| `scripts/ai-commit` | Optional wrapper around `git commit` for agent commits. |
+| `.worktrees/<flattened-branch>/` | Active agent worktrees (`fix/foo` → `fix-foo`). Removed after merge (requires approval). |
+
+Non-Nix dotfiles (shell, editor, tool configs) live at the repo root and under conventional `XDG_CONFIG_HOME` paths.
+
+---
+
+## Environment facts
+
+- **Hosts:** the flake provides three NixOS configurations — `WSL` (NixOS-WSL2), `DansSpectre`, `New-H0Ryzen`. Detect the current host before assuming behaviour: `cat /etc/hostname` or `hostnamectl`.
+- **WSL-only specifics:** on `WSL` the kernel comes from the Windows side, not Nix; `/etc/nixos/corp.pem` may be present for the corporate CA (referenced via `builtins.pathExists`), which means rebuilds need `nixos-rebuild switch --flake .#WSL --impure`. These do not apply to `DansSpectre` or `New-H0Ryzen`.
+- **Working baselines for cross-distro debugging:** on `WSL` an Ubuntu/WSL2 install on the same Windows host is available as a side-by-side reference. On other hosts, compare against a previous working generation (`nix profile history`, `/run/current-system` vs the proposed build) instead.
+- **GPG signing fails non-interactively** (`gpg: cannot open '/dev/tty'`) in agent sessions. Use `git commit --no-gpg-sign` unless the user provides another path.
+- **GitHub:** `gh` is authenticated. Inspect PRs/issues/checks directly rather than guessing.
+
+---
+
+## Verification expectations
+
+Before claiming a Nix change is correct:
+
+- `nix eval .#nixosConfigurations.<host>.config.system.build.toplevel.drvPath` must succeed.
+- For changed packages: `nix build .#nixosConfigurations.<host>.config.system.build.toplevel --no-link` (or build the specific derivation) must succeed.
+- Behavioural changes that only manifest after `nixos-rebuild switch` (services, kernel modules, runtime binaries) **cannot be agent-verified end-to-end**. State this explicitly in the PR and propose the post-switch commands the user should run.
+
+Never claim "this fixes X" on the strength of a successful eval alone when X is a runtime symptom.
+
+---
+
+## Debugging discipline
+
+For non-trivial runtime failures (services crashing, packages misbehaving, mounts/perms issues), invoke the `systematic-debugging` skill before proposing a fix.
+
+- Treat the **first** ERROR in a log as the root cause candidate, not the most visible one. Downstream errors are often misleading (e.g. an `EACCES` mount error that's actually downstream of a segfaulting helper).
+- When a working baseline exists (other host running the same package, a parallel non-NixOS install, a previous generation), diff against it before hypothesising.
+- If the user reports a previous fix did not work, ask for the new failure mode before proposing the next change. Do not chain hypotheses without evidence.
+- Falsified hypotheses get recorded in the PR description / commit message so we don't re-run them next time.
+
+---
+
+## Style notes
+
+- **Comments in Nix files: concise (1–3 lines).** Explain the non-obvious *why*; do not restate what the code does.
+- Root-cause analyses, falsified hypotheses, and link-outs to upstream issues belong in commit messages and PR bodies, not in source comments.
+- Prefer hoisting repeated literals (versions, hashes, URLs) into `let` bindings or attributes so they update in one place.

--- a/scripts/agent-cleanup.sh
+++ b/scripts/agent-cleanup.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# scripts/agent-cleanup <branch>
+#
+# Tears down a merged feature branch: removes the worktree under
+# .worktrees/<flattened-branch>, prunes worktree metadata, and deletes
+# the local branch. Must be run from the main worktree (not from inside
+# the worktree being removed).
+#
+# Safety:
+# - Refuses to run from inside .worktrees/.
+# - Refuses to delete a branch whose remote has not been deleted, unless
+#   --force is passed.
+
+BRANCH="${1:-}"
+FORCE=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --force) FORCE=1 ;;
+  esac
+done
+
+if [[ -z "${BRANCH}" || "${BRANCH}" == --* ]]; then
+  echo "Usage: $0 <branch> [--force]"
+  echo "Example: $0 fix/wsl-sbx-shim-segfault"
+  exit 1
+fi
+
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "Error: not inside a git repository."
+  exit 1
+fi
+
+ROOT="$(git rev-parse --show-toplevel)"
+
+# Refuse to run from inside .worktrees/. The current directory would be
+# pulled out from under us when the worktree is removed.
+case "$ROOT" in
+  */.worktrees/*)
+    echo "Error: refuse to run from inside a worktree. cd to the main checkout first."
+    exit 1
+    ;;
+esac
+
+cd "$ROOT"
+
+WORKTREE_NAME="${BRANCH//\//-}"
+TARGET_DIR="$ROOT/.worktrees/$WORKTREE_NAME"
+
+# Update remote tracking so the merged-remote check below is accurate.
+git fetch --prune origin --quiet || true
+
+# Verify the branch was actually merged. If origin/<branch> still exists
+# the PR has not been merged-and-deleted yet; bail unless --force.
+if [[ "$FORCE" -ne 1 ]]; then
+  if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+    echo "Error: origin/$BRANCH still exists. Merge the PR (which deletes the remote branch) first, or re-run with --force."
+    exit 1
+  fi
+fi
+
+# Remove the worktree if present.
+if [[ -d "$TARGET_DIR" ]]; then
+  git worktree remove "$TARGET_DIR"
+  echo "✅ Removed worktree: $TARGET_DIR"
+else
+  echo "ℹ️  No worktree at $TARGET_DIR (already gone)."
+fi
+
+git worktree prune
+
+# Delete the local branch. Use -D because squash-merged branches are not
+# recognised as merged by git's -d check.
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  git branch -D "$BRANCH"
+  echo "✅ Deleted local branch: $BRANCH"
+else
+  echo "ℹ️  No local branch '$BRANCH' (already gone)."
+fi
+
+echo ""
+echo "Cleanup complete."

--- a/scripts/agent-start.sh
+++ b/scripts/agent-start.sh
@@ -36,7 +36,10 @@ git fetch origin main --quiet || {
 }
 
 WORKTREES_DIR="$ROOT/.worktrees"
-TARGET_DIR="$WORKTREES_DIR/$BRANCH"
+# Flatten branch names like "chore/foo" into "chore-foo" so worktrees live
+# directly under .worktrees/ rather than in type-prefixed subdirectories.
+WORKTREE_NAME="${BRANCH//\//-}"
+TARGET_DIR="$WORKTREES_DIR/$WORKTREE_NAME"
 
 mkdir -p "$WORKTREES_DIR"
 


### PR DESCRIPTION
## Summary
- Expand `AGENTS.md` with the context agents previously rediscovered ad hoc each session (repo map, host-aware environment facts, verification expectations, debugging discipline, Nix style notes).
- Flatten worktree paths in `scripts/agent-start.sh` so `chore/foo` lives at `.worktrees/chore-foo` rather than `.worktrees/chore/foo`.
- Add `scripts/agent-cleanup.sh` to tear down a merged branch's worktree and local branch in one safe step.

## Motivation
The recent docker-sbx debugging journey spanned three PRs (#29, the abandoned v0.29.0 pin, and #30) and each session began by reinspecting the same repo layout, rediscovering that GPG signing fails non-interactively, and re-deriving that an Ubuntu/WSL2 baseline existed for comparison. Capturing that baseline context in `AGENTS.md` should make future sessions both faster and less prone to symptom-chasing.

## Changes
- `AGENTS.md`:
  - **Repo map** table covering `flake.nix`, `nix/hosts`, `nix/home`, `nix/modules`, `nix/pkgs`, and the agent scripts.
  - **Environment facts**: lists all three NixOS hosts (`WSL`, `DansSpectre`, `New-H0Ryzen`) and scopes WSL-only specifics (Windows-supplied kernel, optional `corp.pem`, `--impure` requirement) so they don't bleed into other hosts.
  - **Verification expectations**: eval/build before claiming a fix; explicit acknowledgment that post-`switch` runtime behaviour can't be agent-verified end-to-end.
  - **Debugging discipline**: invoke `systematic-debugging`, treat first-error-not-loudest-error as root-cause candidate, diff against working baselines (other host / parallel install / previous generation), don't chain hypotheses without evidence, record falsified hypotheses in PRs.
  - **Style notes**: concise Nix comments (1–3 lines), root-cause analyses go in commits/PRs rather than source, hoist repeated literals to `let` bindings.
  - Worktree workflow snippet updated to reference the flattened directory naming and the new cleanup script.
- `scripts/agent-start.sh`: substitute `/` with `-` in the worktree path. Existing nested worktrees are unaffected; only new invocations get the flat layout.
- `scripts/agent-cleanup.sh` (new): single-command teardown. Refuses to run from inside `.worktrees/`; refuses to delete a branch whose `origin/<branch>` still exists (unless `--force`); uses `git branch -D` because squash-merged branches aren't recognised by `git branch -d`.

## Verification
- `bash -n` on both scripts.
- `scripts/agent-cleanup.sh` invoked without arguments prints usage; invoked from inside this worktree refuses with the expected error.
- `scripts/agent-start.sh` flatten logic verified manually (`fix/foo-bar` → `fix-foo-bar`).