### PR TITLE
✨ feat(git): add work-specific gitconfig for ~/Projects/work

### DIFF
--- a/git/.config/git/config
+++ b/git/.config/git/config
@@ -22,8 +22,8 @@
   gpgSign = true
   sort = -version:refname
 
-[includeIf "gitdir:~/Documents/projects/work/"]
-  path = ~/Documents/projects/work/.gitconfig
+[includeIf "gitdir:~/Projects/work/"]
+  path = ~/Projects/work/.gitconfig
 
 [rerere]
 	enabled = true

--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -125,6 +125,22 @@ in
         (mkConfigLink "zsh")
         (lib.optionalAttrs hasDesktop (mkConfigLink "kitty"))
 
+        # Work-specific git config included via includeIf in the main git config.
+        # Sets work email and disables GPG signing for all repos under ~/Projects/work/.
+        {
+          "Projects/work/.gitconfig".text = ''
+            [user]
+              name = Daniel Lowry
+              email = daniel.lowry@kainos.com
+
+            [commit]
+              gpgSign = false
+
+            [tag]
+              gpgSign = false
+          '';
+        }
+
         # gnupg: manage individual files rather than the whole directory — gpg requires
         # strict 700 permissions on the directory itself, and the directory contains
         # runtime files (sockets, keyrings) that should not be managed by Nix.


### PR DESCRIPTION
## Summary

Automatically creates `~/Projects/work/.gitconfig` via home-manager with:
- Work email: `daniel.lowry@kainos.com`
- GPG signing disabled for commits and tags

The main gitconfig's `includeIf` directive (updated from the old `~/Documents/projects/work/` path) loads this file automatically for any repo under `~/Projects/work/`.

## Changes
- `git/.config/git/config`: Updated `includeIf` path to `~/Projects/work/`
- `nix/home/default.nix`: Added `home.file."Projects/work/.gitconfig"` with work identity and signing overrides