### PR TITLE
📦 feat(nix/copilot): override github-copilot-cli to 1.0.54

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,9 @@
       overlays = [
         (final: prev: {
           docker-sbx = final.callPackage ./nix/pkgs/docker-sbx.nix { };
+          # Track a newer upstream than nixos-unstable currently ships; drop
+          # this override when nixpkgs catches up.
+          github-copilot-cli = final.callPackage ./nix/pkgs/github-copilot-cli.nix { };
         })
       ];
 

--- a/nix/pkgs/github-copilot-cli.nix
+++ b/nix/pkgs/github-copilot-cli.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  stdenv,
+  autoPatchelfHook,
+  cacert,
+  fetchurl,
+  glib,
+  libsecret,
+  makeBinaryWrapper,
+  bash,
+  nodejs,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+# Local override of nixpkgs' github-copilot-cli to track a newer upstream
+# release than nixos-unstable currently ships. Delete this file (and the
+# overlay entry in flake.nix) once nixpkgs catches up to this version or
+# newer.
+stdenv.mkDerivation (finalAttrs: {
+  pname = "github-copilot-cli";
+  version = "1.0.54";
+
+  # GitHub provide platform-specific SEA binaries as well as a "universal"
+  # package.  Use the universal package as it gives us a bit more flexibility
+  # about how it's configured.  In particular, the SEA binary has fixed ideas
+  # about how paths should be set up which don't reliably hold when using Nix.
+  src = fetchurl {
+    url = "https://github.com/github/copilot-cli/releases/download/v${finalAttrs.version}/github-copilot-${finalAttrs.version}.tgz";
+    hash = "sha256-WkJtCfapWdmZPPDEtfZhDJzgPgcI2NpTgukCyhBfzcY=";
+  };
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    stdenv.cc.cc.lib
+    glib
+    libsecret
+  ];
+  sourceRoot = "package";
+  dontStrip = true;
+  # computer.node requires GUI/media libraries (X11, pipewire, libei, libjpeg,
+  # libpng) for screen-capture and input-simulation features that are not
+  # relevant for CLI use; ignore those missing deps rather than fail the build
+  # or pull in heavy dependencies.
+  #
+  # keytar ships musl-libc prebuilds (linuxmusl-{x64,arm64}) alongside the
+  # glibc ones; the glibc build is what actually loads on NixOS, so ignore
+  # libc.musl-x86_64.so.1 from the unused musl variants rather than try to
+  # provide musl on a glibc system.
+  autoPatchelfIgnoreMissingDeps = [
+    "libX11.so.6"
+    "libXtst.so.6"
+    "libjpeg.so.8"
+    "libpng16.so.16"
+    "libpipewire-0.3.so.0"
+    "libei.so.1"
+    "libc.musl-x86_64.so.1"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out"/lib/github-copilot-cli
+    cp -r * "$out"/lib/github-copilot-cli
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    makeWrapper ${nodejs}/bin/node "$out"/bin/copilot \
+      --add-flag "$out"/lib/github-copilot-cli/index.js \
+      --add-flag --no-auto-update \
+      --set-default NODE_NO_WARNINGS 1 \
+      --set-default SSL_CERT_DIR ${cacert}/etc/ssl/certs \
+      --prefix PATH : "${lib.makeBinPath [ bash ]}"
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  # TODO are these errors still present after moving to using the "universal"
+  # package?
+  doInstallCheck = !stdenv.hostPlatform.isDarwin; # skip on Darwin - OpenSSL errors in sandbox
+
+  # Looks like GitHub use tags for both pre-release and actually released
+  # versions, but only the actual versions will be available as a GitHub
+  # release, so use the release endpoint rather than nix-update-script`'s
+  # default of looking for tags.
+  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
+
+  meta = {
+    description = "GitHub Copilot CLI brings the power of Copilot coding agent directly to your terminal";
+    homepage = "https://github.com/github/copilot-cli";
+    changelog = "https://github.com/github/copilot-cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [
+      dbreyfogle
+      me-and
+    ];
+    mainProgram = "copilot";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+})


### PR DESCRIPTION
## Summary

`nixos-unstable` currently ships `github-copilot-cli` 1.0.26. Upstream is at 1.0.54. This PR vendors a local copy of the upstream `package.nix` bumped to 1.0.54 and exposes it via the existing overlay, mirroring the `docker-sbx` pattern.

## Approach

Three options were considered (full writeup in the brainstorming session that produced this PR):

- **Option A (chosen): local overlay package.** Copy upstream `package.nix` to `nix/pkgs/github-copilot-cli.nix`, bump version + hash, expose via the existing overlay.
- **Option B: `overrideAttrs` inline.** Rejected — `finalAttrs.version` is baked into the upstream `src.url`, so you must override `src` with an inlined URL anyway; `autoPatchelfIgnoreMissingDeps` drift between releases is silent; loses an audit-friendly copy of the derivation.
- **Option C: second nixpkgs input.** Rejected — `nixos-unstable` doesn't yet have 1.0.54.

Option B's risk materialised during the build (see below), validating the choice.

## What had to change beyond the version + hash

Upstream's `autoPatchelfIgnoreMissingDeps` needed one addition: `libc.musl-x86_64.so.1`. Between 1.0.26 and 1.0.54, `keytar` started shipping musl prebuilds (`linuxmusl-x64/keytar.node`, `linuxmusl-arm64/keytar.node`) whose libc is unsatisfiable on glibc NixOS. The glibc `keytar` prebuild is what actually loads, so the musl variants are correctly ignored rather than satisfied.

## Verification

| Check | Result |
| --- | --- |
| `nix eval` WSL `system.build.toplevel.drvPath` | ✅ |
| `nix eval` DansSpectre `system.build.toplevel.drvPath` | ✅ |
| `nix eval` New-H0Ryzen `system.build.toplevel.drvPath` | ✅ |
| `nix build` of the `github-copilot-cli` derivation (includes `versionCheckHook`) | ✅ |
| `nix build` WSL `system.build.toplevel --impure` | ✅ |
| Built binary `copilot --version` | reports `GitHub Copilot CLI 1.0.54` |

DansSpectre and New-H0Ryzen full toplevel builds were not run on this WSL host (they would download host-specific deps that aren't cached here). Their `nix eval` passing is sufficient evidence that the Nix expression is correct for those hosts; the actual `nixos-rebuild switch` on each machine will perform the build.

Per `AGENTS.md`, runtime behaviour beyond `--version` cannot be agent-verified. After merge, run on each host:

```bash
sudo nixos-rebuild switch --flake .#$HOST $( [[ "$HOST" == "WSL" ]] && echo --impure )
copilot --version  # expect: GitHub Copilot CLI 1.0.54
```

## Maintenance

Delete `nix/pkgs/github-copilot-cli.nix` and the overlay entry in `flake.nix` once `nixpkgs` catches up to ≥ 1.0.54. The file's header comment notes this.