### PR TITLE
🔧 chore(scripts): preserve slashes in worktree paths, look up by branch name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,9 @@ This file is the source of truth for how coding agents must operate in this repo
 # Create worktree + install hooks
 ./scripts/agent-start.sh <branch>
 
-# Work inside the worktree (slashes in the branch name are flattened to dashes)
-# e.g. branch "fix/foo-bar" → .worktrees/fix-foo-bar
-cd .worktrees/<flattened-branch>
+# Work inside the worktree (slashes in the branch name are preserved as
+# nested directories, e.g. branch "fix/foo-bar" → .worktrees/fix/foo-bar)
+cd .worktrees/<branch>
 
 # Push and open PR
 git push -u origin <branch>
@@ -141,7 +141,7 @@ When a task touches files described in this map, read those files directly. Do *
 | `scripts/agent-start.sh` | Creates the per-branch worktree and installs the co-author hook. |
 | `scripts/agent-cleanup.sh` | Removes a merged branch's worktree and local branch in one step. |
 | `scripts/ai-commit` | Optional wrapper around `git commit` for agent commits. |
-| `.worktrees/<flattened-branch>/` | Active agent worktrees (`fix/foo` → `fix-foo`). Removed after merge (requires approval). |
+| `.worktrees/<branch>/` | Active agent worktrees (slashes in the branch name are preserved as nested directories — `fix/foo` lives at `.worktrees/fix/foo`). Removed after merge (requires approval). |
 
 Non-Nix dotfiles (shell, editor, tool configs) live at the repo root and under conventional `XDG_CONFIG_HOME` paths.
 

--- a/scripts/agent-cleanup.sh
+++ b/scripts/agent-cleanup.sh
@@ -3,10 +3,15 @@ set -euo pipefail
 
 # scripts/agent-cleanup <branch>
 #
-# Tears down a merged feature branch: removes the worktree under
-# .worktrees/<flattened-branch>, prunes worktree metadata, and deletes
-# the local branch. Must be run from the main worktree (not from inside
-# the worktree being removed).
+# Tears down a merged feature branch: removes the worktree (if one is
+# associated with the branch), prunes worktree metadata, deletes the
+# local branch, and removes any newly-empty parent directories under
+# .worktrees/. Must be run from the main worktree (not from inside the
+# worktree being removed).
+#
+# Worktree lookup uses `git worktree list --porcelain` keyed on branch
+# name, so the on-disk path layout is not assumed. This works for the
+# current slash-preserving convention and is robust to future changes.
 #
 # Safety:
 # - Refuses to run from inside .worktrees/.
@@ -46,8 +51,18 @@ esac
 
 cd "$ROOT"
 
-WORKTREE_NAME="${BRANCH//\//-}"
-TARGET_DIR="$ROOT/.worktrees/$WORKTREE_NAME"
+# Find the worktree path for this branch via porcelain output, which
+# parses as paired `worktree <path>` / `branch refs/heads/<name>` lines.
+# Returns empty if no worktree is associated with the branch.
+find_worktree_path() {
+  local branch="$1"
+  git worktree list --porcelain | awk -v branch="refs/heads/$branch" '
+    /^worktree / { path = substr($0, 10) }
+    /^branch /   { if ($2 == branch) { print path; exit } }
+  '
+}
+
+TARGET_DIR="$(find_worktree_path "$BRANCH")"
 
 # Update remote tracking so the merged-remote check below is accurate.
 git fetch --prune origin --quiet || true
@@ -61,12 +76,22 @@ if [[ "$FORCE" -ne 1 ]]; then
   fi
 fi
 
-# Remove the worktree if present.
-if [[ -d "$TARGET_DIR" ]]; then
+# Remove the worktree if one is registered for this branch.
+if [[ -n "$TARGET_DIR" ]]; then
   git worktree remove "$TARGET_DIR"
   echo "✅ Removed worktree: $TARGET_DIR"
+
+  # Clean up newly-empty parent directories under .worktrees/. rmdir is
+  # safe here — it only succeeds on empty dirs, so non-empty siblings
+  # are left untouched. Walk upward until we hit .worktrees/ itself or
+  # a non-empty directory.
+  parent="$(dirname "$TARGET_DIR")"
+  while [[ "$parent" != "$ROOT/.worktrees" && "$parent" != "$ROOT" && "$parent" != "/" ]]; do
+    rmdir "$parent" 2>/dev/null || break
+    parent="$(dirname "$parent")"
+  done
 else
-  echo "ℹ️  No worktree at $TARGET_DIR (already gone)."
+  echo "ℹ️  No worktree associated with branch '$BRANCH' (already gone or never existed)."
 fi
 
 git worktree prune

--- a/scripts/agent-cleanup.sh
+++ b/scripts/agent-cleanup.sh
@@ -81,15 +81,21 @@ if [[ -n "$TARGET_DIR" ]]; then
   git worktree remove "$TARGET_DIR"
   echo "✅ Removed worktree: $TARGET_DIR"
 
-  # Clean up newly-empty parent directories under .worktrees/. rmdir is
-  # safe here — it only succeeds on empty dirs, so non-empty siblings
-  # are left untouched. Walk upward until we hit .worktrees/ itself or
-  # a non-empty directory.
-  parent="$(dirname "$TARGET_DIR")"
-  while [[ "$parent" != "$ROOT/.worktrees" && "$parent" != "$ROOT" && "$parent" != "/" ]]; do
-    rmdir "$parent" 2>/dev/null || break
-    parent="$(dirname "$parent")"
-  done
+  # Clean up newly-empty parent directories — but only when the worktree
+  # lived strictly inside $ROOT/.worktrees/. Worktrees in other locations
+  # (created with a custom path) are left alone; rmdir'ing arbitrary
+  # parents outside .worktrees/ is not this script's job.
+  #
+  # The trailing slash in the prefix is load-bearing: it means
+  # $ROOT/.worktrees itself never matches, so the loop terminates
+  # naturally at the .worktrees/ boundary without needing extra checks.
+  if [[ "$TARGET_DIR" == "$ROOT/.worktrees/"* ]]; then
+    parent="$(dirname "$TARGET_DIR")"
+    while [[ "$parent" == "$ROOT/.worktrees/"* ]]; do
+      rmdir "$parent" 2>/dev/null || break
+      parent="$(dirname "$parent")"
+    done
+  fi
 else
   echo "ℹ️  No worktree associated with branch '$BRANCH' (already gone or never existed)."
 fi

--- a/scripts/agent-start.sh
+++ b/scripts/agent-start.sh
@@ -41,9 +41,6 @@ git fetch origin main --quiet || {
 }
 
 WORKTREES_DIR="$ROOT/.worktrees"
-# Preserve slashes in branch names as nested directories. git worktree add
-# handles the mkdir -p, and agent-cleanup.sh finds worktrees via
-# `git worktree list --porcelain` rather than reconstructing the path.
 TARGET_DIR="$WORKTREES_DIR/$BRANCH"
 
 mkdir -p "$WORKTREES_DIR"

--- a/scripts/agent-start.sh
+++ b/scripts/agent-start.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 #
 # Creates a worktree at .worktrees/<branch> based on origin/main and
 # configures worktree-local hooks/helpers to ensure AI co-author attribution.
+#
+# Branch names containing slashes (e.g. "feat/foo") are preserved as nested
+# directories under .worktrees/ (e.g. .worktrees/feat/foo). Companion script
+# agent-cleanup.sh uses `git worktree list --porcelain` to locate worktrees
+# by branch name, so the on-disk path layout is not assumed.
 
 BRANCH="${1:-}"
 
@@ -36,10 +41,10 @@ git fetch origin main --quiet || {
 }
 
 WORKTREES_DIR="$ROOT/.worktrees"
-# Flatten branch names like "chore/foo" into "chore-foo" so worktrees live
-# directly under .worktrees/ rather than in type-prefixed subdirectories.
-WORKTREE_NAME="${BRANCH//\//-}"
-TARGET_DIR="$WORKTREES_DIR/$WORKTREE_NAME"
+# Preserve slashes in branch names as nested directories. git worktree add
+# handles the mkdir -p, and agent-cleanup.sh finds worktrees via
+# `git worktree list --porcelain` rather than reconstructing the path.
+TARGET_DIR="$WORKTREES_DIR/$BRANCH"
 
 mkdir -p "$WORKTREES_DIR"
 


### PR DESCRIPTION
## Summary

Replaces the path-flattening worktree naming convention with native slash-preserving paths, and rewrites `agent-cleanup.sh` to find worktrees via `git worktree list --porcelain` keyed on branch name rather than reconstructing paths. The parent-directory cleanup is guarded to operate only inside `$ROOT/.worktrees/`.

Motivated by a bug discovered in a recent cleanup session: an old worktree at `.worktrees/chore/agents-improve-context-and-debugging` (created before the flattening convention) was invisible to `agent-cleanup.sh`, which only knew how to look at `.worktrees/chore-agents-improve-context-and-debugging`. Cleanup required falling back to native `git worktree remove`.

## Commits

This PR contains two atomic commits — review them in order.

### `🔧 chore(scripts): preserve slashes in worktree paths, look up by branch name`

- **`scripts/agent-start.sh`** — drop `WORKTREE_NAME="${BRANCH//\//-}"` flattening. `TARGET_DIR="$WORKTREES_DIR/$BRANCH"` — slashes become nested directories. `git worktree add` already does the necessary `mkdir -p`.
- **`scripts/agent-cleanup.sh`** — new `find_worktree_path()` parses `git worktree list --porcelain` and matches on `branch refs/heads/<name>`. Empty result means no worktree is registered for the branch, in which case the script falls through gracefully and still deletes the local branch. After `git worktree remove`, walks upward and rmdirs newly-empty parent directories under `.worktrees/`.
- **`AGENTS.md`** — Worktree Workflow section and Repo map updated to document the new slash-preserving layout.

### `🔒 fix(scripts): guard parent-dir cleanup to within .worktrees/`

Strengthens the rmdir-empty-parents loop so it operates **only** on directories strictly inside `$ROOT/.worktrees/`. Without this guard, a worktree at an unusual location (e.g. someone manually ran `git worktree add /home/user/scratch/foo`) would cause the loop to walk up `/home/user/scratch` → `/home/user` → `/home`, rmdir'ing each one if it happened to be empty — well outside this script's remit.

The fix replaces the previous exclusion-based boundary (`!= ".worktrees" && != "$ROOT" && != "/"`) with an inclusion-based prefix check (`== "$ROOT/.worktrees/"*`). The trailing slash is load-bearing: `$ROOT/.worktrees` itself does not match, so the loop terminates naturally at the boundary without needing explicit stopping points. An entry guard with the same condition skips the loop entirely when the worktree was outside the conventional location.

## Verification

- `bash -n` on both scripts: syntax OK.
- `awk` parser tested against live `git worktree list --porcelain`:
  - finds an existing slash branch (`chore/agent-scripts-slash-paths`)
  - finds the main worktree (`main`)
  - returns empty string for a non-existent branch, falling through to the no-worktree branch in the script
- `rmdir`-empty-parents loop tested in a tmpfs sandbox across five scenarios:
  1. Slash worktree with sibling → parent kept (non-empty) ✅
  2. Slash worktree empties its parent → parent removed, `.worktrees/` preserved ✅
  3. Flat-style worktree → loop exits immediately at `.worktrees/` boundary ✅
  4. Worktree outside `.worktrees/` (e.g. `$ROOT/elsewhere/`) → entry guard prevents any rmdir ✅
  5. `$TARGET_DIR == $ROOT/.worktrees` exactly (degenerate) → entry guard prevents self-removal ✅

Test 4 is specifically what the second commit addresses.

## Migration

None needed. The session that prompted this change already deleted every pre-existing flat-style worktree. New worktrees created after merge will use the slash-preserving layout from `agent-start.sh`.

## Future-proofing

By using `git worktree list --porcelain` for the lookup, `agent-cleanup.sh` is no longer coupled to any specific path convention. If the convention is ever changed again, or if a user manually creates a worktree at an unusual location, cleanup will still find it as long as the branch name is correct — and the parent-cleanup guard ensures it won't touch directories outside `.worktrees/` even in that case.