### PR TITLE
🐛 fix(zsh): buffer --help pipeline through tempfile to avoid SIGTTOU stall

### DIFF
--- a/zsh/.config/zsh/.zshrc
+++ b/zsh/.config/zsh/.zshrc
@@ -66,9 +66,20 @@ alias eza="eza --icons --long --git --all --group-directories-first"
 alias vim="nvim"
 alias wget="wget --hsts-file=$XDG_CACHE_HOME/wget-hsts"
 
-# Use bat to colourise help text (use \-h to escape flag when not used as help)
-alias -g -- -h='-h 2>&1 | bat --language=help --style=plain'
-alias -g -- --help='--help 2>&1 | bat --language=help --style=plain'
+# Colourised help pager (use \-h to escape flag when not used as help).
+# Buffer through a temp file: some CLIs (e.g. opencode) start in their own
+# process group, so writes to the tty from inside a pipeline trigger SIGTTOU
+# and stop the pipeline — visible as `j` echoing instead of scrolling in the
+# pager. Draining to a file first means less only ever sees a regular file.
+_help_pager() {
+  local tmp
+  tmp=$(mktemp -t help.XXXXXX) || return
+  cat >"$tmp"
+  bat --language=help --style=plain --color=always --paging=never -- "$tmp" | less -R
+  rm -f -- "$tmp"
+}
+alias -g -- -h='-h 2>&1 | _help_pager'
+alias -g -- --help='--help 2>&1 | _help_pager'
 
 ##########################
 # Git Worktree Functions #


### PR DESCRIPTION
## Problem

The global `--help` / `-h` aliases in `.zshrc` pipe a command's output through `bat`, which spawns `less` as its pager. For most commands this works, but `opencode --help` (and likely other Bun-bundled CLIs) leaves the downstream `less` in a half-broken state: pressing `j` / `k` echoes the character into the terminal's line-discipline buffer instead of scrolling, and only takes effect after pressing Enter.

## Root cause

`opencode` puts itself in a new process group (`setpgid()`) early in startup. When such a process writes to the controlling tty from inside a pipeline launched by the interactive shell, the kernel delivers `SIGTTOU` and stops the pipeline. `less`, downstream, never gets EOF on its stdin pipe and never transitions cleanly into its raw-mode interactive state — so keystrokes fall through to the shell's cooked-mode line discipline.

Verified by `ps -o pid,pgid,sid,stat ...`: `opencode --help` shows up with its own PGID (distinct from the shell's), state `TN` (stopped, low priority).

## Fix

Buffer the upstream command's output through a `mktemp` temp file, then page that file. The upstream process only writes to a regular file (no tty involvement, no `SIGTTOU`), and `less` reads from a normal seekable source. Confirmed by Test E during diagnosis: `opencode --help | bat --paging=never > /tmp/x; less /tmp/x` works correctly.

Also adds `--color=always` so bat keeps colour when its output is piped (previously the simpler `| less` shape lost colour because bat's `--color=auto` disabled it when stdout wasn't a tty).

## Falsified hypotheses (recorded so we don't re-check them)

- bat's default less flags `-RFK`: same symptom with `-R`, `-RF`, `-RK`, or bare `-R`. Not a flag issue.
- opencode leaving the tty in raw mode: `stty -a` before / after `opencode --help` is identical, whether stdout is `/dev/null` or a pipe.
- ANSI escape sequences in `opencode --help` output: `od -c` shows none.
- Lingering opencode child processes / unclosed pipe writers: `ps` and `/proc/*/fd` inspection show none.
- NixOS `programs.less` generating an empty lesskey `#command` block (which less 690+ treats as "clear defaults"): the bug reproduces identically on Arch with no such file.

## Verification

- `zsh -n zsh/.config/zsh/.zshrc` passes syntax check.
- Behavioural verification (`opencode --help` scrolls correctly under `j` / `k`) requires sourcing the new `.zshrc` in an interactive shell — that's the post-merge step the user needs to run.