### PR TITLE
✨ feat(gnome): enable dark mode, green accent, and Qt adwaita-dark

### DIFF
--- a/nix/modules/desktop/gnome.nix
+++ b/nix/modules/desktop/gnome.nix
@@ -18,6 +18,23 @@
 
     networking.networkmanager.enable = true;
 
+    # Dark mode default + green accent; user can still override in GNOME Settings.
+    programs.dconf.profiles.user.databases = [
+      {
+        settings."org/gnome/desktop/interface" = {
+          color-scheme = "prefer-dark";
+          accent-color = "green";
+        };
+      }
+    ];
+
+    # Qt apps use adwaita-dark to match GNOME's dark theme.
+    qt = {
+      enable = true;
+      platformTheme = "gnome";
+      style = "adwaita-dark";
+    };
+
     # Remove unwanted GNOME default applications entirely.
     environment.gnome.excludePackages = with pkgs; [
       decibels # Audio player

--- a/nix/modules/desktop/gnome.nix
+++ b/nix/modules/desktop/gnome.nix
@@ -18,7 +18,6 @@
 
     networking.networkmanager.enable = true;
 
-    # Dark mode default + green accent; user can still override in GNOME Settings.
     programs.dconf.profiles.user.databases = [
       {
         settings."org/gnome/desktop/interface" = {
@@ -28,7 +27,6 @@
       }
     ];
 
-    # Qt apps use adwaita-dark to match GNOME's dark theme.
     qt = {
       enable = true;
       platformTheme = "gnome";


### PR DESCRIPTION
- Set color-scheme = prefer-dark via system dconf profile (overridable in GNOME Settings)
- Set accent-color = green via the same dconf profile
- Enable qt.platformTheme = gnome with style = adwaita-dark so Qt apps match

Co-authored-by: Copilot <copilot@github.com>
