### PR TITLE
🔧 chore(kitty): remap URL open to ctrl+click

### DIFF
--- a/kitty/.config/kitty/kitty.conf
+++ b/kitty/.config/kitty/kitty.conf
@@ -5,3 +5,5 @@ font_family      family="DejaVuSansM Nerd Font Mono"
 bold_font        auto
 italic_font      auto
 bold_italic_font auto
+
+mouse_map ctrl+left release grabbed,ungrabbed mouse_handle_click selection link prompt


### PR DESCRIPTION
Default is ctrl+shift+click; remapping to ctrl+click for convenience.

Co-authored-by: Copilot <copilot@github.com>
