### PR TITLE
✨ feat(firefox): declarative config via home-manager

### DIFF
--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -13,6 +13,8 @@ let
   hasDesktop = osConfig != null && (osConfig.gnome.enable or false);
 in
 {
+  imports = [ ./firefox.nix ];
+
   home = {
     username = "dandyrow";
     homeDirectory = "/home/dandyrow";

--- a/nix/home/firefox.nix
+++ b/nix/home/firefox.nix
@@ -1,4 +1,5 @@
 {
+  config,
   pkgs,
   lib,
   osConfig ? null,
@@ -12,8 +13,7 @@ in
 lib.mkIf hasDesktop {
   programs.firefox = {
     enable = true;
-    # Keep legacy profile path; remove once stateVersion is bumped to 26.05+.
-    configPath = ".mozilla/firefox";
+    configPath = "${config.xdg.configHome}/mozilla/firefox";
 
     policies = {
       DisableTelemetry = true;

--- a/nix/home/firefox.nix
+++ b/nix/home/firefox.nix
@@ -14,7 +14,9 @@ lib.mkIf hasDesktop {
   programs.firefox = {
     enable = true;
     configPath = "${config.xdg.configHome}/mozilla/firefox";
-    nativeMessagingHosts = [ pkgs.gnome-browser-connector ];
+    package = pkgs.firefox.override {
+      nativeMessagingHosts = [ pkgs.gnome-browser-connector ];
+    };
 
     policies = {
       DisableTelemetry = true;

--- a/nix/home/firefox.nix
+++ b/nix/home/firefox.nix
@@ -1,0 +1,110 @@
+{
+  pkgs,
+  lib,
+  osConfig ? null,
+  ...
+}:
+let
+  hasDesktop = osConfig != null && (osConfig.gnome.enable or false);
+  # Helper to build an AMO download URL from an add-on slug.
+  amo = slug: "https://addons.mozilla.org/firefox/downloads/latest/${slug}/latest.xpi";
+in
+lib.mkIf hasDesktop {
+  programs.firefox = {
+    enable = true;
+    # Keep legacy profile path; remove once stateVersion is bumped to 26.05+.
+    configPath = ".mozilla/firefox";
+
+    policies = {
+      DisableTelemetry = true;
+      DisablePocket = true;
+      DisableFirefoxStudies = true;
+      DisableFirefoxAccounts = true;
+      OfferToSaveLogins = false;
+
+      # force_installed: Firefox fetches from AMO on first launch; user cannot remove.
+      ExtensionSettings = {
+        "uBlock0@raymondhill.net" = {
+          install_url = amo "ublock-origin";
+          installation_mode = "force_installed";
+        };
+        "{446900e4-71c2-419f-a6a7-df9c091e268b}" = {
+          install_url = amo "bitwarden-password-manager";
+          installation_mode = "force_installed";
+        };
+        "addon@darkreader.org" = {
+          install_url = amo "darkreader";
+          installation_mode = "force_installed";
+        };
+      };
+    };
+
+    profiles.default = {
+      isDefault = true;
+
+      search = {
+        # Prevents Firefox resetting the search config on updates.
+        force = true;
+        default = "ddg";
+
+        engines = {
+          "Nix Packages" = {
+            urls = [
+              {
+                template = "https://search.nixos.org/packages";
+                params = [
+                  {
+                    name = "channel";
+                    value = "unstable";
+                  }
+                  {
+                    name = "query";
+                    value = "{searchTerms}";
+                  }
+                ];
+              }
+            ];
+            icon = "${pkgs.nixos-icons}/share/icons/hicolor/scalable/apps/nix-snowflake.svg";
+            definedAliases = [ "@np" ];
+          };
+
+          "Nix Options" = {
+            urls = [
+              {
+                template = "https://search.nixos.org/options";
+                params = [
+                  {
+                    name = "channel";
+                    value = "unstable";
+                  }
+                  {
+                    name = "query";
+                    value = "{searchTerms}";
+                  }
+                ];
+              }
+            ];
+            icon = "${pkgs.nixos-icons}/share/icons/hicolor/scalable/apps/nix-snowflake.svg";
+            definedAliases = [ "@no" ];
+          };
+
+          "NixOS Wiki" = {
+            urls = [
+              {
+                template = "https://wiki.nixos.org/w/index.php";
+                params = [
+                  {
+                    name = "search";
+                    value = "{searchTerms}";
+                  }
+                ];
+              }
+            ];
+            icon = "${pkgs.nixos-icons}/share/icons/hicolor/scalable/apps/nix-snowflake.svg";
+            definedAliases = [ "@nw" ];
+          };
+        };
+      };
+    };
+  };
+}

--- a/nix/home/firefox.nix
+++ b/nix/home/firefox.nix
@@ -14,6 +14,7 @@ lib.mkIf hasDesktop {
   programs.firefox = {
     enable = true;
     configPath = "${config.xdg.configHome}/mozilla/firefox";
+    nativeMessagingHosts = [ pkgs.gnome-browser-connector ];
 
     policies = {
       DisableTelemetry = true;

--- a/nix/hosts/DansSpectre/configuration.nix
+++ b/nix/hosts/DansSpectre/configuration.nix
@@ -3,7 +3,6 @@
   documentation.nixos.enable = false;
 
   programs = {
-    firefox.enable = true;
     git.enable = true;
     steam.enable = true;
   };

--- a/nix/hosts/New-H0Ryzen/configuration.nix
+++ b/nix/hosts/New-H0Ryzen/configuration.nix
@@ -15,7 +15,6 @@
   documentation.nixos.enable = false;
 
   programs = {
-    firefox.enable = true;
     git.enable = true;
     steam.enable = true;
   };

--- a/nix/modules/desktop/gnome.nix
+++ b/nix/modules/desktop/gnome.nix
@@ -18,6 +18,8 @@
 
     networking.networkmanager.enable = true;
 
+    services.gnome.gnome-browser-connector.enable = true;
+
     programs.dconf.profiles.user.databases = [
       {
         settings."org/gnome/desktop/interface" = {


### PR DESCRIPTION
- New nix/home/firefox.nix module (imported from default.nix, guarded by hasDesktop)
- Privacy policies: DisableTelemetry, DisablePocket, DisableFirefoxStudies,
  DisableFirefoxAccounts, OfferToSaveLogins = false
- Extensions via policies.ExtensionSettings (force_installed from AMO):
  uBlock Origin, Bitwarden, Dark Reader
- Default search engine: DuckDuckGo
- Custom search aliases: @np (NixOS packages), @no (NixOS options), @nw (NixOS wiki)
- Removes programs.firefox.enable from host configs; HM now owns the install
- Pins configPath to legacy .mozilla/firefox until stateVersion is bumped to 26.05+

Co-authored-by: Copilot <copilot@github.com>
