### PR TITLE
🔧 chore(nix): set home-manager.backupFileExtension to bak

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,8 @@
               home-manager.useGlobalPkgs = true;
               home-manager.useUserPackages = true;
               home-manager.users.dandyrow = import ./nix/home;
+              # Prevent activation failures when HM wants to overwrite pre-existing files.
+              home-manager.backupFileExtension = "bak";
             }
           ]
           ++ lib.optionals (host == "WSL") [


### PR DESCRIPTION
Prevents HM activation failures when pre-existing files (e.g.
profiles.ini from a previous Firefox install) would be clobbered
by managed generations.

Co-authored-by: Copilot <copilot@github.com>
