### PR TITLE
✨ feat(firefox): pin extensions to toolbar and lock new tab layout

### DIFF
--- a/nix/home/firefox.nix
+++ b/nix/home/firefox.nix
@@ -26,19 +26,35 @@ lib.mkIf hasDesktop {
       OfferToSaveLogins = false;
 
       # force_installed: Firefox fetches from AMO on first launch; user cannot remove.
+      # default_area = "navbar": pin the icon to the toolbar (Firefox 113+).
       ExtensionSettings = {
         "uBlock0@raymondhill.net" = {
           install_url = amo "ublock-origin";
           installation_mode = "force_installed";
+          default_area = "navbar";
         };
         "{446900e4-71c2-419f-a6a7-df9c091e268b}" = {
           install_url = amo "bitwarden-password-manager";
           installation_mode = "force_installed";
+          default_area = "navbar";
         };
         "addon@darkreader.org" = {
           install_url = amo "darkreader";
           installation_mode = "force_installed";
+          default_area = "navbar";
         };
+      };
+
+      # Remove distracting sections from the new tab page and lock the settings
+      # so Firefox cannot reset them on update.
+      FirefoxHome = {
+        TopSites = false;
+        SponsoredTopSites = false;
+        Pocket = false;
+        Stories = false;
+        SponsoredPocket = false;
+        SponsoredStories = false;
+        Locked = true;
       };
     };
 


### PR DESCRIPTION
- Add default_area = "navbar" to all three force_installed extensions
  (uBlock Origin, Bitwarden, Dark Reader) so their icons appear on the
  navigation bar rather than the overflow/extensions menu (Firefox 113+).

- Add FirefoxHome policy to remove Shortcuts (TopSites) and Recommended
  Stories (Pocket/Stories) from the new tab page; Locked = true prevents
  Firefox or the user from re-enabling them without a rebuild.

Co-authored-by: Copilot <copilot@github.com>
