### PR TITLE
🐛 fix(gnome): always show logout in system menu

### DIFF
--- a/nix/modules/desktop/gnome.nix
+++ b/nix/modules/desktop/gnome.nix
@@ -22,9 +22,13 @@
 
     programs.dconf.profiles.user.databases = [
       {
-        settings."org/gnome/desktop/interface" = {
-          color-scheme = "prefer-dark";
-          accent-color = "green";
+        settings = {
+          "org/gnome/desktop/interface" = {
+            color-scheme = "prefer-dark";
+            accent-color = "green";
+          };
+          # Always show logout in the system menu regardless of user count.
+          "org/gnome/shell".always-show-log-out = true;
         };
       }
     ];

--- a/nix/modules/desktop/gnome.nix
+++ b/nix/modules/desktop/gnome.nix
@@ -27,7 +27,6 @@
             color-scheme = "prefer-dark";
             accent-color = "green";
           };
-          # Always show logout in the system menu regardless of user count.
           "org/gnome/shell".always-show-log-out = true;
         };
       }


### PR DESCRIPTION
GNOME hides the logout entry when only one user account exists on the
system. Set always-show-log-out = true so it is always visible.

Co-authored-by: Copilot <copilot@github.com>
