### PR TITLE
✨ feat(opencode): add terminal-bell plugin for idle/permission events

### DIFF
--- a/opencode/.config/opencode/plugins/terminal-bell.ts
+++ b/opencode/.config/opencode/plugins/terminal-bell.ts
@@ -1,0 +1,13 @@
+import type { Plugin } from "@opencode-ai/plugin"
+
+const BELL = "\x07"
+
+export const TerminalBellPlugin: Plugin = async () => {
+  return {
+    event: async ({ event }) => {
+      if (event.type === "session.idle" || event.type === "permission.asked") {
+        process.stdout.write(BELL)
+      }
+    },
+  }
+}


### PR DESCRIPTION
## What

Adds a small local opencode plugin at `opencode/.config/opencode/plugins/terminal-bell.ts` (stowed to `~/.config/opencode/plugins/`) that writes a BEL character (`\x07`) to stdout when:

- `session.idle` — opencode finished its turn
- `permission.asked` — opencode is waiting on user approval

opencode auto-loads any `.ts`/`.js` file from `~/.config/opencode/plugins/`, so no `opencode.json` change is needed.

## Why

opencode has no built-in notification config field — its JSON schema rejects unknown top-level keys. The documented path for "ping me when opencode needs me / finishes" is a plugin that subscribes to events. A terminal bell is the lightest-weight option and composes with whatever the terminal emulator already does with bells (notify daemon mapping, urgent flag, dock bounce, etc.).

## Verification

- Schema/API checked against <https://opencode.ai/config.json> and <https://opencode.ai/docs/plugins/> — `event` hook + `session.idle` / `permission.asked` event types are documented.
- Static only: cannot agent-verify the bell actually fires. After merge + restart, the user can confirm by triggering a permission prompt or waiting for a turn to finish in a terminal where the bell is audible/visible.

## Post-merge

User needs to **quit and restart opencode** for the new plugin to load — config and plugins are not hot-reloaded.