### PR TITLE
🔧 fix(tmux): set extended-keys-format to csi-u for pi compatibility

### DIFF
--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -20,6 +20,7 @@ set -g set-clipboard on
 
 set -s focus-events on
 set -s extended-keys on
+set -g extended-keys-format csi-u
 set -s escape-time 5
 
 # Colours


### PR DESCRIPTION
Co-authored-by: Copilot <copilot@github.com>
