### PR TITLE
🔧 fix(home): hide cups Manage Printing entry from GNOME app menu

### DIFF
--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -187,14 +187,17 @@ in
     };
   };
 
-  # Hide CLI tools from the GNOME app menu. These packages ship .desktop files
-  # so GNOME picks them up and shows them in the app launcher, but they are
-  # terminal applications and have no business appearing there. Overriding each
-  # entry with NoDisplay=true removes them from the menu while keeping the
-  # binaries fully available in the terminal.
+  # Hide packages from the GNOME app menu that have no place in the launcher.
+  # These ship .desktop files that GNOME picks up automatically; overriding
+  # each entry with NoDisplay=true suppresses the menu entry while keeping the
+  # package fully functional.
   xdg.desktopEntries = {
     btop = {
       name = "btop++";
+      noDisplay = true;
+    };
+    cups = {
+      name = "Manage Printing";
       noDisplay = true;
     };
     nvim = {


### PR DESCRIPTION
The cups package ships cups.desktop which opens the CUPS web interface
at localhost:631. It has no NoDisplay flag so GNOME shows it in the
app launcher as "Manage Printing". Override it with NoDisplay=true via
xdg.desktopEntries, matching the existing pattern used for btop/nvim/yazi.

Also updates the block comment to describe the pattern accurately for
non-CLI packages.

Co-authored-by: Copilot <copilot@github.com>
