### PR TITLE
🐛 fix(kitty): use Nerd Font v3 non-Mono variant for correct icon sizing

### DIFF
--- a/kitty/.config/kitty/kitty.conf
+++ b/kitty/.config/kitty/kitty.conf
@@ -1,7 +1,7 @@
 # Enable catppuccin mocha theme
 include current-theme.conf
 
-font_family      family="DejaVuSansM Nerd Font Mono"
+font_family      family="DejaVuSansM Nerd Font"
 bold_font        auto
 italic_font      auto
 bold_italic_font auto

--- a/kitty/.config/kitty/kitty.conf
+++ b/kitty/.config/kitty/kitty.conf
@@ -5,5 +5,6 @@ font_family      family="DejaVuSansM Nerd Font"
 bold_font        auto
 italic_font      auto
 bold_italic_font auto
+font_size        14.0
 
 mouse_map ctrl+left release grabbed,ungrabbed mouse_handle_click selection link prompt


### PR DESCRIPTION
The Mono variant forces all glyphs into a single character cell, making
icons appear smaller than surrounding text. Kitty handles double-wide
characters natively so the standard (non-Mono) variant is correct.

Co-authored-by: Copilot <copilot@github.com>
