### PR TITLE
🐛 fix(nix/desktop): fix VLC UI interaction on GNOME Wayland

### DIFF
--- a/nix/hosts/DansSpectre/hardware-configuration.nix
+++ b/nix/hosts/DansSpectre/hardware-configuration.nix
@@ -41,6 +41,9 @@
       # Power on the adapter at boot so it is ready without manual intervention.
       powerOnBoot = true;
     };
+
+    # intel-media-driver provides iHD_drv_video.so for VA-API on the Intel HD 630 iGPU (Gen9.5).
+    graphics.extraPackages = with pkgs; [ intel-media-driver ];
   };
 
   # Kaby Lake G has two GPUs in the same package:

--- a/nix/modules/desktop/gnome.nix
+++ b/nix/modules/desktop/gnome.nix
@@ -38,6 +38,9 @@
       style = "adwaita-dark";
     };
 
+    # qgnomeplatform forces Qt5 apps to XCB/XWayland even in a Wayland session; this overrides it.
+    environment.sessionVariables.QT_QPA_PLATFORM = "wayland;xcb";
+
     # Remove unwanted GNOME default applications entirely.
     environment.gnome.excludePackages = with pkgs; [
       decibels # Audio player


### PR DESCRIPTION
## Problem

VLC opens but its UI is frozen and unresponsive.

## Root cause

Three issues compound:

1. **`qgnomeplatform` forces Qt5 to XCB/XWayland.** `qt.platformTheme = "gnome"` sets `QT_QPA_PLATFORMTHEME=gnome`, which loads `qgnomeplatform`. That plugin explicitly ignores `XDG_SESSION_TYPE=wayland` on GNOME and forces Qt5 apps onto the XCB/XWayland backend, emitting the warning `Ignoring XDG_SESSION_TYPE=wayland on Gnome`.

2. **VA-API fails under XWayland.** XWayland does not expose the X11 `DRI2` extension (`Xlib: extension "DRI2" missing on display ":0"`), so VLC's `glconv_vaapi_x11` path fails. `glconv_vaapi_drm` also fails because `iHD_drv_video.so` (Intel Media Driver) was not installed. Neither fallback succeeds.

3. **Failure cascade freezes the UI thread.** The VA-API failures trigger a filter recursion bug in VLC 3.x (`chain filter error: Too high level of recursion (3)`) → `video output creation failed` → `failed to create video output` → VLC's UI thread stalls.

Note: `radeonsi_drv_video.so` (AMD Vega M VA-API) is already present via Mesa, but it is only reachable via the Wayland/DRM path, not via XWayland.

## Fix

| File | Change |
|------|--------|
| `nix/modules/desktop/gnome.nix` | `environment.sessionVariables.QT_QPA_PLATFORM = "wayland;xcb"` — overrides `qgnomeplatform`'s XCB-forcing behaviour; Qt5 apps prefer native Wayland and VLC's VA-API routes to the AMD GPU DRM path where `radeonsi_drv_video.so` is available |
| `nix/hosts/DansSpectre/hardware-configuration.nix` | `hardware.graphics.extraPackages = [ intel-media-driver ]` — provides `iHD_drv_video.so` for the Intel HD 630 iGPU (Gen9.5) |

## Verification

`nix eval` passes: `iv4s267wls3lq28nnlqi7fdaywyipf03-nixos-system-DansSpectre-26.05.20260523.64c08a7.drv`

These changes only take effect after `nixos-rebuild switch`. After switching, verify with:

```bash
# VLC should launch without the qgnomeplatform XCB warning
vlc 2>&1 | grep -i "wayland\|xcb\|warning"

# VA-API should now find both drivers
vainfo --display drm --device /dev/dri/renderD128  # AMD (radeonsi)
vainfo --display drm --device /dev/dri/renderD129  # Intel (iHD)
```