### PR TITLE
⬆️ chore(nix/pkgs): bump docker-sbx to 0.31.2

### DIFF
--- a/nix/pkgs/docker-sbx.nix
+++ b/nix/pkgs/docker-sbx.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  version = "0.30.0";
+  version = "0.31.2";
 in
 stdenv.mkDerivation {
   pname = "docker-sbx";
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
 
   src = fetchzip {
     url = "https://github.com/docker/sbx-releases/releases/download/v${version}/DockerSandboxes-linux.tar.gz";
-    hash = "sha256-uO4HM+iCm4OHe727y0PVzzhV77LP7UG4MuCX6Tn9hBU=";
+    hash = "sha256-cKMsXIj8NXlTGvL2mB3BxtCnUgfhVER38FT+3K/r7oo=";
     stripRoot = true;
   };
 


### PR DESCRIPTION
Nixpkgs does not package docker-sbx; we vendor it. Previous pin was 0.30.0; this tracks the latest upstream release.

Verified:

- nix eval succeeds for WSL, DansSpectre, New-H0Ryzen toplevels

- nix build of the package succeeds on $HOST

- `sbx version` reports Client Version v0.31.2

Delete this override once nixpkgs ships docker-sbx >= 0.31.2.

Co-authored-by: Copilot <copilot@github.com>
