### PR TITLE
⬆️ chore(nix/pkgs): bump github-copilot-cli to 1.0.60

### DIFF
--- a/nix/pkgs/github-copilot-cli.nix
+++ b/nix/pkgs/github-copilot-cli.nix
@@ -19,7 +19,7 @@
 # newer.
 stdenv.mkDerivation (finalAttrs: {
   pname = "github-copilot-cli";
-  version = "1.0.54";
+  version = "1.0.60";
 
   # GitHub provide platform-specific SEA binaries as well as a "universal"
   # package.  Use the universal package as it gives us a bit more flexibility
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   # about how paths should be set up which don't reliably hold when using Nix.
   src = fetchurl {
     url = "https://github.com/github/copilot-cli/releases/download/v${finalAttrs.version}/github-copilot-${finalAttrs.version}.tgz";
-    hash = "sha256-WkJtCfapWdmZPPDEtfZhDJzgPgcI2NpTgukCyhBfzcY=";
+    hash = "sha256-wUEBstKx8Yb9m6ynIi137ZXR7dO39uepnv/yGFVE/qQ=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
nixos-unstable ships 1.0.54; this override tracks 1.0.60 ahead of
nixpkgs. Delete nix/pkgs/github-copilot-cli.nix and the overlay entry
in flake.nix once nixpkgs catches up to 1.0.60 or newer.

Verified:
- nix eval succeeded for WSL, DansSpectre, and New-H0Ryzen
- nix build succeeded: /nix/store/gn4q818diqgzvz1szw077wyap7yk47fy-github-copilot-cli-1.0.60
- copilot --version reports: GitHub Copilot CLI 1.0.60

Co-authored-by: Copilot <copilot@github.com>
