### PR TITLE
✨ feat(nix): add catppuccin/nix + Papirus-Dark icon theme

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "catppuccin": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1780833533,
+        "narHash": "sha256-0StMUC1sOkiQq7qoLQpobwVlad09EA5cy7HZit172Fw=",
+        "owner": "catppuccin",
+        "repo": "nix",
+        "rev": "4dd4177dc14b0c0b23bf3ce403f813be0c4c30de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "catppuccin",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
     "disko": {
       "inputs": {
         "nixpkgs": [
@@ -99,6 +117,19 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1780365719,
+        "narHash": "sha256-JX05Ms/dk0c+UoW9IqQriB53HNZFckX9Qd3EJqmcqEw=",
+        "rev": "ffa10e26ae11d676b2db836259889f1f571cb14f",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1009182.ffa10e26ae11/nixexprs.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
         "lastModified": 1779560665,
         "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "nixos",
@@ -115,11 +146,12 @@
     },
     "root": {
       "inputs": {
+        "catppuccin": "catppuccin",
         "disko": "disko",
         "home-manager": "home-manager",
         "nix-index-database": "nix-index-database",
         "nixos-wsl": "nixos-wsl",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,8 @@
       url = "github:nix-community/NixOS-WSL";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    catppuccin.url = "github:catppuccin/nix";
   };
 
   outputs =
@@ -68,7 +70,12 @@
             {
               home-manager.useGlobalPkgs = true;
               home-manager.useUserPackages = true;
-              home-manager.users.dandyrow = import ./nix/home;
+              home-manager.users.dandyrow = {
+                imports = [
+                  ./nix/home
+                  inputs.catppuccin.homeModules.catppuccin
+                ];
+              };
               # Prevent activation failures when HM wants to overwrite pre-existing files.
               home-manager.backupFileExtension = "bak";
             }
@@ -96,7 +103,10 @@
             # and the unfree predicate is applied via nixpkgs.config in mkSystem instead.
             config = { inherit allowUnfreePredicate; };
           };
-          modules = [ ./nix/home ];
+          modules = [
+            ./nix/home
+            inputs.catppuccin.homeModules.catppuccin
+          ];
           extraSpecialArgs = { inherit wsl; };
         };
 

--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -37,6 +37,14 @@ in
       ++ lib.optionals (osConfig != null && (osConfig.gnome.enable or false)) [
         kitty
       ]
+      ++ lib.optionals hasDesktop (
+        with pkgs.gnomeExtensions;
+        [
+          appindicator
+          dash-to-dock
+          status-area-horizontal-spacing
+        ]
+      )
       ++ [
         # Zsh dependencies (see zsh dotfile README)
         fzf
@@ -227,4 +235,35 @@ in
   # Move ~/.nix-defexpr and ~/.nix-profile to XDG state directory.
   # use-xdg-base-directories is enabled system-wide in common/default.nix.
   nix.assumeXdg = true;
+
+  catppuccin = {
+    enable = true;
+    autoEnable = false;
+    flavor = "mocha";
+    accent = "green";
+    firefox = lib.mkIf hasDesktop {
+      enable = true;
+      force = true;
+    };
+  };
+
+  gtk = lib.mkIf hasDesktop {
+    enable = true;
+    iconTheme = {
+      name = "Papirus-Dark";
+      package = pkgs.catppuccin-papirus-folders.override {
+        flavor = "mocha";
+        accent = "green";
+      };
+    };
+  };
+
+  dconf.settings = lib.mkIf hasDesktop {
+    "org/gnome/desktop/interface".icon-theme = lib.mkDefault "Papirus-Dark";
+    "org/gnome/shell".enabled-extensions = [
+      "appindicatorsupport@rgcjonas.gmail.com"
+      "dash-to-dock@micxgx.gmail.com"
+      "status-area-horizontal-spacing@mathematical.coffee.gmail.com"
+    ];
+  };
 }

--- a/nix/home/firefox.nix
+++ b/nix/home/firefox.nix
@@ -43,10 +43,6 @@ lib.mkIf hasDesktop {
           installation_mode = "force_installed";
           default_area = "navbar";
         };
-        "{f4363cd3-9ba9-453d-b2b2-66e6e1bafe73}" = {
-          install_url = amo "catppuccin-mocha-green-git";
-          installation_mode = "force_installed";
-        };
       };
 
       # Remove distracting sections from the new tab page and lock the settings
@@ -64,11 +60,6 @@ lib.mkIf hasDesktop {
 
     profiles.default = {
       isDefault = true;
-
-      settings = {
-        # force_installed themes are not auto-activated; this pref selects the active one.
-        "extensions.activeThemeID" = "{f4363cd3-9ba9-453d-b2b2-66e6e1bafe73}";
-      };
 
       search = {
         # Prevents Firefox resetting the search config on updates.


### PR DESCRIPTION
## Summary

Adds [catppuccin/nix](https://github.com/catppuccin/nix) as the declarative source of truth for Catppuccin theming, replaces the manually force-installed Firefox extension, sets Papirus-Dark with Catppuccin Mocha Green folder colours as the default GNOME icon theme, and installs the Papirus-recommended GNOME extensions.

## Changes

### `flake.nix`
- Added `catppuccin.url = "github:catppuccin/nix"` input (no `follows` clause — catppuccin/nix manages its own nixpkgs compat)
- Wired `catppuccin.homeModules.catppuccin` via `home-manager.sharedModules` in `mkSystem` and directly in `mkHome`
- NixOS-level catppuccin module omitted — no system-level theming is needed at this time

### `nix/home/default.nix`
- Global catppuccin block: `enable = true`, `autoEnable = false`, `flavor = "mocha"`, `accent = "green"`
  - `autoEnable = false` prevents silent future auto-enrollment of ports
- `catppuccin.firefox` enabled on desktop hosts (`force = true` acknowledges the HM extensions.settings override)
- GTK icon theme set to Papirus-Dark via `catppuccin-papirus-folders.override { flavor = "mocha"; accent = "green"; }`
- Belt-and-suspenders `dconf.settings."org/gnome/desktop/interface".icon-theme = lib.mkDefault "Papirus-Dark"`
- Three Papirus-recommended GNOME extensions added (package + dconf `enabled-extensions`):
  - AppIndicator Support (`appindicatorsupport@rgcjonas.gmail.com`)
  - Dash to Dock (`dash-to-dock@micxgx.gmail.com`)
  - Status Area Horizontal Spacing (`status-area-horizontal-spacing@mathematical.coffee.gmail.com`)
  - _No Symbolic Icons_ dropped: abandoned upstream, absent from nixpkgs, unsupported on GNOME 45+

### `nix/home/firefox.nix`
- Removed `{f4363cd3-9ba9-453d-b2b2-66e6e1bafe73}` force-installed extension (catppuccin-mocha-green-git AMO)
- Removed `extensions.activeThemeID` profile pref
- Both are fully superseded by `catppuccin.firefox.enable = true`

## Affected hosts
- **DansSpectre**, **New-H0Ryzen**: Papirus-Dark icons, Catppuccin Firefox theme, 3 GNOME extensions installed and enabled
- **WSL**: unaffected (`hasDesktop` guard in home-manager config)

## Verification
All three nixosConfigurations evaluate cleanly:
```
nix eval .#nixosConfigurations.DansSpectre.config.system.build.toplevel.drvPath  # ✓
nix eval .#nixosConfigurations.New-H0Ryzen.config.system.build.toplevel.drvPath  # ✓
nix eval .#nixosConfigurations.WSL.config.system.build.toplevel.drvPath          # ✓
nix flake check                                                                    # all checks passed
```

## Post-switch verification (user action required)
After `nixos-rebuild switch`:
```bash
# Confirm icon theme
gsettings get org.gnome.desktop.interface icon-theme
# Expected: 'Papirus-Dark'

# Confirm extensions enabled
gnome-extensions list --enabled
# Expected: appindicatorsupport@..., dash-to-dock@..., status-area-horizontal-spacing@...

# Confirm Firefox theme (open Firefox — should show Catppuccin Mocha Green theme)
```