### PR TITLE
feat/neovim react ts setup

### DIFF
--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -79,11 +79,13 @@ in
         basedpyright
         # gh_actions_ls (github-actions-language-server) is not yet in nixpkgs;
         # it will fall back to Mason on non-Nix systems or be unavailable on Nix.
-        vscode-langservers-extracted # provides jsonls
+        vscode-langservers-extracted # provides jsonls, cssls, eslint, html LSPs
         gopls
         ansible-language-server
         typescript-language-server
         nixd
+        tailwindcss-language-server
+        emmet-language-server
 
         # Formatters
         beautysh
@@ -95,6 +97,7 @@ in
         # conflicts with gopls. goimports functionality is covered by gopls on Nix.
         eslint_d
         nixfmt # nixfmt-rfc-style is now an alias for nixfmt
+        prettier
 
         # Linters
         shellcheck
@@ -105,6 +108,7 @@ in
         delve
         python3Packages.debugpy
         vscode-extensions.vadimcn.vscode-lldb # codelldb
+        vscode-js-debug
       ]
       ++ lib.optionals (pkgs.stdenv.hostPlatform.system == "x86_64-linux") [
         # docker-sbx is only published for x86_64-linux; no aarch64 release.

--- a/nvim/.config/nvim/lua/config/tools.lua
+++ b/nvim/.config/nvim/lua/config/tools.lua
@@ -22,6 +22,7 @@ M.formatters = {
   "goimports",
   "gofumpt",
   "eslint_d",
+  "prettier",
 }
 
 M.linters = {
@@ -33,7 +34,7 @@ M.linters = {
   -- jsonls (vscode-langservers-extracted) instead. Mason installs it on non-Nix.
   "jsonlint",
   "golangci-lint",
-  "eslint_d",
+  -- eslint_d removed: the eslint LSP provides real-time JS/TS diagnostics instead.
 }
 
 M.dap_adapters = {
@@ -42,6 +43,7 @@ M.dap_adapters = {
   "bash-debug-adapter",
   "debugpy",
   "delve",
+  "js-debug-adapter",
 }
 
 return M

--- a/nvim/.config/nvim/lua/config/tools.lua
+++ b/nvim/.config/nvim/lua/config/tools.lua
@@ -34,7 +34,6 @@ M.linters = {
   -- jsonls (vscode-langservers-extracted) instead. Mason installs it on non-Nix.
   "jsonlint",
   "golangci-lint",
-  -- eslint_d removed: the eslint LSP provides real-time JS/TS diagnostics instead.
 }
 
 M.dap_adapters = {

--- a/nvim/.config/nvim/lua/plugins/autotag.lua
+++ b/nvim/.config/nvim/lua/plugins/autotag.lua
@@ -1,0 +1,5 @@
+return {
+  "windwp/nvim-ts-autotag",
+  event = { "BufReadPre", "BufNewFile" },
+  opts = {},
+}

--- a/nvim/.config/nvim/lua/plugins/autotag.lua
+++ b/nvim/.config/nvim/lua/plugins/autotag.lua
@@ -2,8 +2,6 @@ return {
   "windwp/nvim-ts-autotag",
   event = { "BufReadPre", "BufNewFile" },
   opts = {
-    opts = {
-      enable_close_on_slash = true,
-    },
+    enable_close_on_slash = true,
   },
 }

--- a/nvim/.config/nvim/lua/plugins/autotag.lua
+++ b/nvim/.config/nvim/lua/plugins/autotag.lua
@@ -1,5 +1,9 @@
 return {
   "windwp/nvim-ts-autotag",
   event = { "BufReadPre", "BufNewFile" },
-  opts = {},
+  opts = {
+    opts = {
+      enable_close_on_slash = true,
+    },
+  },
 }

--- a/nvim/.config/nvim/lua/plugins/cmp.lua
+++ b/nvim/.config/nvim/lua/plugins/cmp.lua
@@ -83,7 +83,6 @@ return {
               end,
             },
             kind = {
-              -- (optional) use highlights from mini.icons
               highlight = function(ctx)
                 local _, hl, _ = require("mini.icons").get("lsp", ctx.kind)
                 return hl

--- a/nvim/.config/nvim/lua/plugins/cmp.lua
+++ b/nvim/.config/nvim/lua/plugins/cmp.lua
@@ -31,6 +31,7 @@ return {
     "moyiz/blink-emoji.nvim",
     "fang2hou/blink-copilot",
     "disrupted/blink-cmp-conventional-commits",
+    "brenoprata10/nvim-highlight-colors",
   },
   version = "1.*",
   opts = {
@@ -60,8 +61,23 @@ return {
 
           components = {
             kind_icon = {
-              -- (optional) use highlights from mini.icons
+              text = function(ctx)
+                local icon = ctx.kind_icon
+                if ctx.item.source_name == "LSP" then
+                  local color_item = require("nvim-highlight-colors").format(ctx.item.documentation, { kind = ctx.kind })
+                  if color_item and color_item.abbr ~= "" then
+                    icon = color_item.abbr
+                  end
+                end
+                return icon .. ctx.icon_gap
+              end,
               highlight = function(ctx)
+                if ctx.item.source_name == "LSP" then
+                  local color_item = require("nvim-highlight-colors").format(ctx.item.documentation, { kind = ctx.kind })
+                  if color_item and color_item.abbr_hl_group then
+                    return color_item.abbr_hl_group
+                  end
+                end
                 local _, hl, _ = require("mini.icons").get("lsp", ctx.kind)
                 return hl
               end,

--- a/nvim/.config/nvim/lua/plugins/conform.lua
+++ b/nvim/.config/nvim/lua/plugins/conform.lua
@@ -12,8 +12,10 @@ return {
       ["yaml.ansible"] = { "ansible-lint" },
       yaml = { "yamlfmt" },
       go = { "goimports", "gofumpt" },
-      javascript = { "eslint_d" },
-      typescript = { "eslint_d" },
+      javascript = { "prettier", "eslint_d" },
+      typescript = { "prettier", "eslint_d" },
+      typescriptreact = { "prettier", "eslint_d" },
+      javascriptreact = { "prettier", "eslint_d" },
       nix = { "nixfmt-rfc-style" },
     },
     formatters = {

--- a/nvim/.config/nvim/lua/plugins/conform.lua
+++ b/nvim/.config/nvim/lua/plugins/conform.lua
@@ -1,3 +1,5 @@
+local js_formatters = { "prettier", "eslint_d" }
+
 return {
   "stevearc/conform.nvim",
   event = { "BufWritePre" },
@@ -12,10 +14,10 @@ return {
       ["yaml.ansible"] = { "ansible-lint" },
       yaml = { "yamlfmt" },
       go = { "goimports", "gofumpt" },
-      javascript = { "prettier", "eslint_d" },
-      typescript = { "prettier", "eslint_d" },
-      typescriptreact = { "prettier", "eslint_d" },
-      javascriptreact = { "prettier", "eslint_d" },
+      javascript = js_formatters,
+      typescript = js_formatters,
+      typescriptreact = js_formatters,
+      javascriptreact = js_formatters,
       nix = { "nixfmt-rfc-style" },
     },
     formatters = {

--- a/nvim/.config/nvim/lua/plugins/dap/adapters.lua
+++ b/nvim/.config/nvim/lua/plugins/dap/adapters.lua
@@ -50,3 +50,22 @@ dap.adapters.python = function(cb, config)
     })
   end
 end
+
+-- vscode-js-debug adapter for JavaScript / TypeScript / React debugging.
+-- On Nix: provided by pkgs.vscode-js-debug (js-debug-dap binary on PATH).
+-- On non-Nix: Mason installs js-debug-adapter; binary at the Mason data path.
+local js_debug_cmd = system.is_nix()
+  and vim.fn.exepath("js-debug-dap")
+  or vim.fn.stdpath("data") .. "/mason/packages/js-debug-adapter/js-debug-dap"
+
+for _, type in ipairs({ "pwa-node", "pwa-chrome", "pwa-msedge", "node-terminal", "pwa-extensionHost" }) do
+  dap.adapters[type] = {
+    type = "server",
+    host = "localhost",
+    port = "${port}",
+    executable = {
+      command = js_debug_cmd,
+      args = { "${port}" },
+    },
+  }
+end

--- a/nvim/.config/nvim/lua/plugins/dap/adapters.lua
+++ b/nvim/.config/nvim/lua/plugins/dap/adapters.lua
@@ -54,12 +54,15 @@ end
 -- vscode-js-debug adapter for JavaScript / TypeScript / React debugging.
 -- On Nix: provided by pkgs.vscode-js-debug (js-debug-dap binary on PATH).
 -- On non-Nix: Mason installs js-debug-adapter; binary at the Mason data path.
-local js_debug_cmd = system.is_nix()
-  and vim.fn.exepath("js-debug-dap")
-  or vim.fn.stdpath("data") .. "/mason/packages/js-debug-adapter/js-debug-dap"
+local js_debug_cmd
+if system.is_nix() then
+  js_debug_cmd = vim.fn.exepath("js-debug-dap")
+else
+  js_debug_cmd = vim.fn.stdpath("data") .. "/mason/packages/js-debug-adapter/js-debug-dap"
+end
 
-for _, type in ipairs({ "pwa-node", "pwa-chrome", "pwa-msedge", "node-terminal", "pwa-extensionHost" }) do
-  dap.adapters[type] = {
+for _, adapter_type in ipairs({ "pwa-node", "pwa-chrome", "pwa-msedge", "node-terminal", "pwa-extensionHost" }) do
+  dap.adapters[adapter_type] = {
     type = "server",
     host = "localhost",
     port = "${port}",

--- a/nvim/.config/nvim/lua/plugins/dap/configurations.lua
+++ b/nvim/.config/nvim/lua/plugins/dap/configurations.lua
@@ -91,3 +91,29 @@ dap.configurations.python = {
     end,
   },
 }
+
+local js_configs = {
+  {
+    type = "pwa-node",
+    request = "launch",
+    name = "Node: Launch current file",
+    program = "${file}",
+    cwd = "${workspaceFolder}",
+    sourceMaps = true,
+  },
+  {
+    type = "pwa-chrome",
+    request = "launch",
+    name = "Chrome: Launch and attach to dev server",
+    url = function()
+      local url = vim.fn.input("Dev server URL (default: http://localhost:3000): ")
+      return url ~= "" and url or "http://localhost:3000"
+    end,
+    webRoot = "${workspaceFolder}",
+    sourceMaps = true,
+  },
+}
+
+for _, ft in ipairs({ "javascript", "typescript", "typescriptreact", "javascriptreact" }) do
+  dap.configurations[ft] = js_configs
+end

--- a/nvim/.config/nvim/lua/plugins/highlight-colors.lua
+++ b/nvim/.config/nvim/lua/plugins/highlight-colors.lua
@@ -1,0 +1,8 @@
+return {
+  "brenoprata10/nvim-highlight-colors",
+  event = { "BufReadPre", "BufNewFile" },
+  opts = {
+    render = "virtual",
+    enable_tailwind = true,
+  },
+}

--- a/nvim/.config/nvim/lua/plugins/lint.lua
+++ b/nvim/.config/nvim/lua/plugins/lint.lua
@@ -12,8 +12,6 @@ return {
       ["yaml.ansible"] = { "ansible_lint" },
       json = { "jsonlint" },
       go = { "golangcilint" },
-      javascript = { "eslint_d" },
-      typescript = { "eslint_d" },
       nix = { "nix" },
     }
 

--- a/nvim/.config/nvim/lua/plugins/lsp.lua
+++ b/nvim/.config/nvim/lua/plugins/lsp.lua
@@ -100,6 +100,14 @@ return {
           },
         }
       end)(),
+      tailwindcss = {
+        filetypes = { "html", "css", "typescriptreact", "javascriptreact" },
+      },
+      cssls = {},
+      eslint = {},
+      emmet_language_server = {
+        filetypes = { "html", "typescriptreact", "javascriptreact", "css", "scss" },
+      },
     }
 
     local function merge_unique(...)
@@ -187,6 +195,10 @@ return {
               vim.api.nvim_clear_autocmds({ group = "lsp-highlight", buffer = event2.buf })
             end,
           })
+        end
+
+        if client and client:supports_method(vim.lsp.protocol.Methods.textDocument_inlayHint, event.buf) then
+          vim.lsp.inlay_hint.enable(true, { bufnr = event.buf })
         end
       end,
     })

--- a/nvim/.config/nvim/lua/plugins/neotest.lua
+++ b/nvim/.config/nvim/lua/plugins/neotest.lua
@@ -1,0 +1,47 @@
+return {
+  "nvim-neotest/neotest",
+  dependencies = {
+    "nvim-neotest/nvim-nio",
+    "nvim-lua/plenary.nvim",
+    "marilari88/neotest-jest",
+    "marilari88/neotest-vitest",
+  },
+  config = function()
+    require("neotest").setup({
+      adapters = {
+        require("neotest-jest"),
+        require("neotest-vitest"),
+      },
+    })
+  end,
+  keys = {
+    {
+      "<leader>tr",
+      function()
+        require("neotest").run.run()
+      end,
+      desc = "Test: run nearest",
+    },
+    {
+      "<leader>tf",
+      function()
+        require("neotest").run.run(vim.fn.expand("%"))
+      end,
+      desc = "Test: run file",
+    },
+    {
+      "<leader>ts",
+      function()
+        require("neotest").summary.toggle()
+      end,
+      desc = "Test: toggle summary",
+    },
+    {
+      "<leader>to",
+      function()
+        require("neotest").output_panel.toggle()
+      end,
+      desc = "Test: toggle output panel",
+    },
+  },
+}

--- a/nvim/.config/nvim/lua/plugins/treesitter.lua
+++ b/nvim/.config/nvim/lua/plugins/treesitter.lua
@@ -17,6 +17,7 @@ return {
       "json",
       "javascript",
       "typescript",
+      "tsx",
       "nix",
     })
   end,


### PR DESCRIPTION
- **✨ feat(nvim): add tsx treesitter parser**
- **✨ feat(nvim): add tailwindcss, cssls, eslint, emmet LSPs and inlay hints**
- **✨ feat(nvim): add prettier + eslint_d formatter chain for JS/TS/JSX/TSX**
- **🔧 chore(nvim): remove eslint_d linter — superseded by eslint LSP**
- **✨ feat(nvim): add nvim-ts-autotag for JSX tag auto-close and rename**
- **✨ feat(nvim): add neotest with jest and vitest adapters**
- **✨ feat(nvim): add vscode-js-debug DAP adapter for JS/TS/React**
- **🔧 fix(nvim): rename loop var and align nix/mason style in js dap adapter**
- **🔧 chore(nvim): add prettier and js-debug-adapter to tools; remove eslint_d from linters**
- **✨ feat(nix): add prettier, tailwindcss-ls, emmet-ls, vscode-js-debug packages**
