### PR TITLE
🐛 fix(nvim): restrict highlight-colors to web filetypes only

### DIFF
--- a/nvim/.config/nvim/lua/plugins/highlight-colors.lua
+++ b/nvim/.config/nvim/lua/plugins/highlight-colors.lua
@@ -1,8 +1,25 @@
+local enabled_filetypes = {
+  css = true,
+  scss = true,
+  sass = true,
+  less = true,
+  html = true,
+  javascript = true,
+  javascriptreact = true,
+  typescript = true,
+  typescriptreact = true,
+  vue = true,
+  svelte = true,
+}
+
 return {
   "brenoprata10/nvim-highlight-colors",
   event = { "BufReadPre", "BufNewFile" },
   opts = {
     render = "virtual",
     enable_tailwind = true,
+    exclude_buffer = function(bufnr)
+      return not enabled_filetypes[vim.bo[bufnr].filetype]
+    end,
   },
 }

--- a/nvim/.config/nvim/lua/plugins/highlight-colors.lua
+++ b/nvim/.config/nvim/lua/plugins/highlight-colors.lua
@@ -1,25 +1,9 @@
-local enabled_filetypes = {
-  css = true,
-  scss = true,
-  sass = true,
-  less = true,
-  html = true,
-  javascript = true,
-  javascriptreact = true,
-  typescript = true,
-  typescriptreact = true,
-  vue = true,
-  svelte = true,
-}
-
 return {
   "brenoprata10/nvim-highlight-colors",
   event = { "BufReadPre", "BufNewFile" },
   opts = {
     render = "virtual",
     enable_tailwind = true,
-    exclude_buffer = function(bufnr)
-      return not enabled_filetypes[vim.bo[bufnr].filetype]
-    end,
+    exclude_filetypes = { "lazy", "gitcommit" },
   },
 }


### PR DESCRIPTION
Co-authored-by: Copilot <copilot@github.com>
