### PR TITLE
🐛 fix(nvim): migrate nvim-ts-autotag to new opts layout

### DIFF
--- a/nvim/.config/nvim/lua/plugins/autotag.lua
+++ b/nvim/.config/nvim/lua/plugins/autotag.lua
@@ -2,6 +2,8 @@ return {
   "windwp/nvim-ts-autotag",
   event = { "BufReadPre", "BufNewFile" },
   opts = {
-    enable_close_on_slash = true,
+    opts = {
+      enable_close_on_slash = true,
+    },
   },
 }


### PR DESCRIPTION
Co-authored-by: Copilot <copilot@github.com>
