### PR TITLE
🐛 fix(nvim): restore gd LSP definition keymap for Neovim 0.12

### DIFF
--- a/nvim/.config/nvim/lua/plugins/lsp.lua
+++ b/nvim/.config/nvim/lua/plugins/lsp.lua
@@ -166,6 +166,9 @@ return {
       group = vim.api.nvim_create_augroup("lsp-attach", { clear = true }),
       callback = function(event)
         local client = vim.lsp.get_client_by_id(event.data.client_id)
+
+        -- Neovim 0.12 removed gd from the default LSP keymaps; re-add it.
+        vim.keymap.set("n", "gd", vim.lsp.buf.definition, { buffer = event.buf, desc = "LSP: go to definition" })
         local method = vim.lsp.protocol.Methods.textDocument_documentHighlight
         local supports = function()
           return client:supports_method(method, event.buf)


### PR DESCRIPTION
Neovim 0.12 removed gd from the default LSP keymaps (the new defaults
use the gr* prefix family). Without an explicit mapping, gd falls back
to Vim's built-in 'go to local declaration', which searches the current
buffer and lands on the import statement instead of navigating to the
definition in the source file.

Fix by adding an explicit buffer-local gd -> vim.lsp.buf.definition()
mapping in the LspAttach callback.

Co-authored-by: Copilot <copilot@github.com>
