### PR TITLE
🩹 fix(nix): disable flaky openldap test to unblock bottles build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,10 @@
           # Track a newer upstream than nixos-unstable currently ships; drop
           # this override when nixpkgs catches up.
           github-copilot-cli = final.callPackage ./nix/pkgs/github-copilot-cli.nix { };
+          # test017-syncreplication-refresh is timing-sensitive; drop once cache.nixos.org has this pin.
+          openldap = prev.openldap.overrideAttrs (_: {
+            doCheck = false;
+          });
         })
       ];
 

--- a/nix/hosts/DansSpectre/configuration.nix
+++ b/nix/hosts/DansSpectre/configuration.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ pkgs, ... }:
 {
   documentation.nixos.enable = false;
 
@@ -6,6 +6,10 @@
     git.enable = true;
     steam.enable = true;
   };
+
+  environment.systemPackages = with pkgs; [
+    bottles
+  ];
 
   users.users = {
     dandyrow = {


### PR DESCRIPTION
## Problem

`openldap-2.6.13` fails its build-time test suite (`test017-syncreplication-refresh`) when building from source. This test is timing-sensitive — it uses hardcoded 7-second waits for syncrepl to propagate changes — and fails under sandbox load. This causes a cascade that prevents `bottles` from building (via its `buildFHSEnv` dependency tree).

The binary cache (`cache.nixos.org`) is reachable but doesn't yet have a cached build for the current nixpkgs pin (`26.05.20260523.64c08a7`), so nix falls back to building from source and hits the flaky test.

## Fix

Add `doCheck = false` override for `openldap` in the shared overlay. The resulting binary is identical to what the cache serves — only the test phase is skipped.

## Cleanup

Remove this override once `cache.nixos.org` has the binary for this nixpkgs pin, or after the next `nix flake update` that pulls a commit the cache has already built.