### PR TITLE
🐛 fix(tmux): stop mouse-click text injection by switching extended-keys on→always

### DIFF
--- a/nvim/.config/nvim/lua/config/options.lua
+++ b/nvim/.config/nvim/lua/config/options.lua
@@ -14,6 +14,7 @@ vim.opt.hlsearch = true
 vim.opt.incsearch = true
 
 -- Visual
+vim.opt.background = "dark"
 vim.opt.winborder = "rounded"
 vim.opt.number = true
 vim.opt.relativenumber = true

--- a/nvim/.config/nvim/lua/plugins/catppuccin.lua
+++ b/nvim/.config/nvim/lua/plugins/catppuccin.lua
@@ -13,6 +13,7 @@ return {
   end,
 
   opts = {
+    flavour = "mocha",
     dim_inactive = {
       enabled = true,
       shade = "dark",

--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -19,7 +19,7 @@ set -g detach-on-destroy off
 set -g set-clipboard on
 
 set -s focus-events on
-set -s extended-keys always
+set -s extended-keys on
 set -s escape-time 5
 
 # Colours

--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -19,7 +19,7 @@ set -g detach-on-destroy off
 set -g set-clipboard on
 
 set -s focus-events on
-set -s extended-keys on
+set -s extended-keys always
 set -s escape-time 5
 
 # Colours


### PR DESCRIPTION
## Problem

Clicking between tmux windows with the mouse injects text into the CLI — first `747/5a5a747/5a5a`, then after the initial fix, a long string of hex colour values (`3e3/a1a1...`).

## Root cause (two separate issues)

### Issue 1 — `extended-keys on` (commit 128f2fd)
tmux probes the terminal for extended key support by sending a capability query on every window switch. The terminal's response arrives in the pane's input stream and is injected as literal text (`747/5a5a`).

**Fix:** `extended-keys on` → `extended-keys always`. Enables extended keys unconditionally without probing — no query sent, no response to inject.

### Issue 2 — Neovim OSC colour queries via passthrough (commit 886568b)
When `vim.o.background` is not explicitly set, Neovim 0.10+ sends OSC 11 (background query) and OSC 4;N (full palette query) at startup and on focus events. Inside tmux with `allow-passthrough on`, these are wrapped in DCS passthrough sequences and forwarded to the outer terminal. Windows Terminal (with Catppuccin Mocha applied) responds with its full colour palette — but tmux has no mechanism to route passthrough responses back to the originating application, so the response is injected into the active pane stdin as literal text on every focus gain (i.e. every window switch).

**Fix:** Set `vim.opt.background = "dark"` explicitly in `options.lua` and pin `flavour = "mocha"` in the Catppuccin plugin config. Both values were already the effective runtime values — this just makes them explicit so Neovim never sends the OSC queries.

`allow-passthrough on` is kept — it is required for inline image display in Neovim (snacks.nvim image support).

## Verification

After reloading tmux config (`prefix + r`) and restarting Neovim:
- Click between tmux windows with the mouse — no text should appear in the CLI
- Neovim colours and theme should be identical to before (still Catppuccin Mocha)
- Inline image display should still work

## Rollback

If either fix causes issues: revert `extended-keys always` → `on` (or `off`) and remove the two Neovim lines.