### PR TITLE
🔧 chore(zsh): set DOCKER_CONFIG to XDG config dir

### DIFF
--- a/zsh/.config/zsh/.zshrc
+++ b/zsh/.config/zsh/.zshrc
@@ -36,6 +36,7 @@ export PYTHON_HISTORY="$XDG_STATE_HOME/python_history"
 export PYTHONPYCACHEPREFIX="$XDG_CACHE_HOME/python"
 export PYTHONUSERBASE="$XDG_DATA_HOME/python"
 export COPILOT_HOME="$XDG_CONFIG_HOME/copilot"
+export DOCKER_CONFIG="$XDG_CONFIG_HOME/docker"
 
 # Source Home Manager session variables (adds ~/.nix-profile/bin to PATH,
 # sets NIX_PATH, etc.). Guard ensures this is a no-op before first HM run.


### PR DESCRIPTION
Co-authored-by: Copilot <copilot@github.com>
