### PR TITLE
♻️ refactor(agents): streamline AGENTS.md and extract nix skills

### DIFF
--- a/.agents/skills/bump-nix-package/SKILL.md
+++ b/.agents/skills/bump-nix-package/SKILL.md
@@ -1,13 +1,9 @@
 ---
-applyTo: "nix/pkgs/**,flake.nix"
+name: bump-nix-package
+description: Use when bumping the version of a vendored package under nix/pkgs/ or vendoring a new package into the repo
 ---
 
 # Vendored Nix Package Version Bumps
-
-Fires when editing a repo-local package derivation under `nix/pkgs/` or the
-overlay in `flake.nix`. Use this for bumping the upstream version of a
-vendored package (e.g. tracking `github-copilot-cli` ahead of nixpkgs), or
-for vendoring a new package by copying its upstream `package.nix`.
 
 ## When this applies
 
@@ -64,14 +60,13 @@ updating `nixpkgs` in `flake.nix` and running `nix flake update`.
    confusing `error: path '...' does not exist` from an otherwise valid
    derivation.
 
-6. **Evaluate all three hosts in parallel.** Each must succeed:
+6. **Evaluate all hosts.** Read `flake.nix` to discover the current set of
+   `nixosConfigurations`. Evaluate each — WSL requires `--impure` because
+   its configuration references `/etc/nixos/corp.pem` via `builtins.pathExists`:
    ```bash
+   nix eval .#nixosConfigurations.<host>.config.system.build.toplevel.drvPath
    nix eval .#nixosConfigurations.WSL.config.system.build.toplevel.drvPath --impure
-   nix eval .#nixosConfigurations.DansSpectre.config.system.build.toplevel.drvPath
-   nix eval .#nixosConfigurations.New-H0Ryzen.config.system.build.toplevel.drvPath
    ```
-   (WSL needs `--impure` because `configuration.nix` references
-   `/etc/nixos/corp.pem` via `builtins.pathExists`.)
 
 7. **Build the package itself, not just the host system.**
    ```bash
@@ -88,24 +83,18 @@ updating `nixpkgs` in `flake.nix` and running `nix flake update`.
    /nix/store/...-<name>-<version>/bin/<mainProgram> --version
    ```
 
-9. **Commit.** Use Gitmoji + Conventional Commits per `AGENTS.md`. The
-   commit body should include:
-   - One sentence on why nixpkgs isn't sufficient (current version vs.
-     target version).
-   - Any non-version-non-hash changes (e.g. additions to
-     `autoPatchelfIgnoreMissingDeps`) with one-sentence justifications.
+9. **Commit.** Use gitmoji + conventional commits format. The commit body should include:
+   - One sentence on why nixpkgs isn't sufficient (current version vs target version).
+   - Any non-version-non-hash changes (e.g. additions to `autoPatchelfIgnoreMissingDeps`) with one-sentence justifications.
    - The verification checks that passed.
-   - A "delete this when nixpkgs catches up" line so future-you knows
-     the override is disposable.
+   - A "delete this when nixpkgs catches up" line so future-you knows the override is disposable.
 
-10. **Push + open PR in the same turn.**
+10. **Push + open PR in the same turn.** Pushing a feature branch and
+    opening a PR do not require explicit user approval:
     ```bash
     git push -u origin feat/<pkg>-<version>
     gh pr create --base main --fill
     ```
-    Pushing a feature branch and opening a PR are not destructive and
-    do not need explicit user approval (see `AGENTS.md`,
-    [Irreversible actions](../../AGENTS.md#irreversible-actions-require-explicit-approval-mandatory)).
 
 ## Common failure modes
 
@@ -147,9 +136,9 @@ which means the file is untracked entirely.
 
 ## When `nixos-rebuild switch` is needed
 
-Per `AGENTS.md`, runtime behaviour beyond `--version` cannot be
-agent-verified end-to-end. After the PR merges, propose this to the
-user but do not run it without explicit approval:
+Runtime behaviour beyond `--version` cannot be agent-verified end-to-end.
+After the PR merges, propose this to the user but do not run it without
+explicit approval:
 
 ```bash
 sudo nixos-rebuild switch --flake .#$HOST $( [[ "$HOST" == "WSL" ]] && echo --impure )

--- a/.agents/skills/bump-nix-package/SKILL.md
+++ b/.agents/skills/bump-nix-package/SKILL.md
@@ -1,19 +1,11 @@
 ---
 name: bump-nix-package
-description: Use when bumping the version of a vendored package under nix/pkgs/ or vendoring a new package into the repo
+description: Use when bumping the version of a vendored package under nix/pkgs/, vendoring a new package into the repo, or removing a vendored override once nixpkgs has caught up
 ---
 
 # Vendored Nix Package Version Bumps
 
-## When this applies
-
-- Bumping the `version` of an existing file under `nix/pkgs/`
-- Updating its `hash` / `src.hash` after a version change
-- Adding a new vendored package and wiring it into the overlay in `flake.nix`
-- Removing a vendored override because nixpkgs has caught up
-
-It does **not** apply to nixpkgs-managed packages — those are bumped by
-updating `nixpkgs` in `flake.nix` and running `nix flake update`.
+**REQUIRED SUB-SKILL:** Use `nix-workflow` — it covers **visibility** (staging), host evaluation, and build verification.
 
 ## Recipe (run in order)
 
@@ -30,9 +22,7 @@ updating `nixpkgs` in `flake.nix` and running `nix flake update`.
 3. **Choose: vendor a fresh copy, or `overrideAttrs`?**
    - **Default — vendor a fresh copy.** Copy the current upstream
      `package.nix` into `nix/pkgs/<name>.nix` verbatim, then change
-     `version` and `hash`. Add a 1–2 line header comment marking the file
-     as a tracking override and naming the version at which nixpkgs can
-     reclaim it. Example:
+     `version` and `hash`. Add a 1–2 line tracking header comment. Example:
      ```nix
      # Local override of nixpkgs' <name> to track a newer upstream than
      # nixos-unstable currently ships. Delete this file (and the overlay
@@ -40,11 +30,10 @@ updating `nixpkgs` in `flake.nix` and running `nix flake update`.
      # newer.
      ```
    - **`overrideAttrs` only if** the change is purely `version` + `src` and
-     the upstream derivation is small and stable. Be aware that when
+     the upstream derivation is small and stable. Be aware of **binding**: when
      upstream uses `mkDerivation (finalAttrs: { ... src.url = "...v${finalAttrs.version}..."; })`,
-     overriding `version` alone does **not** change the URL because `src`
-     is already bound to the original `finalAttrs.version`. You must
-     override `src` with the full URL inlined, or use the vendor path.
+     `src` is bound to the original `finalAttrs.version` at definition time. Override `src` with
+     the full URL inlined, or use the vendor path.
 
 4. **Wire into the overlay.** In `flake.nix`, add a line to the existing
    overlay attribute:
@@ -54,21 +43,7 @@ updating `nixpkgs` in `flake.nix` and running `nix flake update`.
    For unfree packages, also ensure the package name is in
    `allowUnfreePredicate`.
 
-5. **Stage immediately.** `git add nix/pkgs/<name>.nix flake.nix`. The
-   flake uses the git tree as its source of truth — `nix eval` and
-   `nix build` cannot see untracked files. Skipping this step produces a
-   confusing `error: path '...' does not exist` from an otherwise valid
-   derivation.
-
-6. **Evaluate all hosts.** Read `flake.nix` to discover the current set of
-   `nixosConfigurations`. Evaluate each — WSL requires `--impure` because
-   its configuration references `/etc/nixos/corp.pem` via `builtins.pathExists`:
-   ```bash
-   nix eval .#nixosConfigurations.<host>.config.system.build.toplevel.drvPath
-   nix eval .#nixosConfigurations.WSL.config.system.build.toplevel.drvPath --impure
-   ```
-
-7. **Build the package itself, not just the host system.**
+5. **Build the package itself, not just the host system.**
    ```bash
    nix build --no-link --print-out-paths .#nixosConfigurations.$HOST.pkgs.<name>
    ```
@@ -77,24 +52,23 @@ updating `nixpkgs` in `flake.nix` and running `nix flake update`.
    library that `autoPatchelfHook` cannot find (see "Common failure
    modes" below), or a `versionCheckHook` mismatch.
 
-8. **Behavioural smoke test.** Run the built binary directly out of the
+6. **Behavioural smoke test.** Run the built binary directly out of the
    nix store and confirm it reports the new version. For most CLIs:
    ```bash
    /nix/store/...-<name>-<version>/bin/<mainProgram> --version
    ```
 
-9. **Commit.** Use gitmoji + conventional commits format. The commit body should include:
+7. **Commit.** The commit body should include:
    - One sentence on why nixpkgs isn't sufficient (current version vs target version).
    - Any non-version-non-hash changes (e.g. additions to `autoPatchelfIgnoreMissingDeps`) with one-sentence justifications.
    - The verification checks that passed.
    - A "delete this when nixpkgs catches up" line so future-you knows the override is disposable.
 
-10. **Push + open PR in the same turn.** Pushing a feature branch and
-    opening a PR do not require explicit user approval:
-    ```bash
-    git push -u origin feat/<pkg>-<version>
-    gh pr create --base main --fill
-    ```
+8. **Push + open PR in the same turn.**
+   ```bash
+   git push -u origin feat/<pkg>-<version>
+   gh pr create --base main --fill
+   ```
 
 ## Common failure modes
 
@@ -118,21 +92,16 @@ to `buildInputs` instead of ignoring it.
 If `nix build` succeeds the patchelf phase but fails at install-check
 with a version mismatch, double-check the new tarball is actually the
 one you intended (`nix-prefetch-url` of the URL embedded in the
-derivation should match the SRI hash). The `finalAttrs.version` /
-`src.url` trap from step 3 above is the usual culprit when using
-`overrideAttrs`.
-
-### "Path does not exist" on `nix eval`
-
-The new `.nix` file isn't staged. Run `git add <path>` (explicit path,
-never `-A` or `.`) and retry. See step 5.
+derivation should match the SRI hash). The **binding** trap from step 3
+is the usual culprit when using `overrideAttrs`.
 
 ### `warning: Git tree '...' is dirty`
 
 Harmless. The flake reads the worktree's git index; uncommitted
 modifications produce this warning but evaluation still uses the
-working-tree contents. Distinct from the "path does not exist" error,
-which means the file is untracked entirely.
+working-tree contents. Distinct from a **visibility** error (`error: path
+'...' does not exist`), which means the file is untracked entirely — see
+`nix-workflow`.
 
 ## When `nixos-rebuild switch` is needed
 
@@ -145,10 +114,10 @@ sudo nixos-rebuild switch --flake .#$HOST $( [[ "$HOST" == "WSL" ]] && echo --im
 <mainProgram> --version  # confirm it picks up the new version
 ```
 
-## When nixpkgs catches up
+## Branch: nixpkgs has caught up
 
-Delete the file under `nix/pkgs/<name>.nix` and the matching line from
-the overlay in `flake.nix`. Verify with the same eval + build checks
-that the nixpkgs-provided package is now at or above the version we
-were tracking, then commit and PR. The "delete this when nixpkgs
-catches up" line in the original commit message helps you find these.
+Delete `nix/pkgs/<name>.nix` and the matching line from the overlay in
+`flake.nix`. Verify with the eval + build checks from `nix-workflow` that
+the nixpkgs-provided package is now at or above the version being tracked,
+then commit and PR. The "delete this when nixpkgs catches up" line in the
+original commit message helps you find these.

--- a/.agents/skills/nix-workflow/SKILL.md
+++ b/.agents/skills/nix-workflow/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: nix-workflow
+description: Use when editing any .nix files or making NixOS configuration changes in this repo
+---
+
+# Nix Workflow
+
+## Before making changes
+
+**Stage new `.nix` files immediately after writing them.** The flake uses the git tree as its source of truth — `nix eval`, `nix build`, and `nix flake check` cannot see untracked files. A new file produces `error: path '...' does not exist` until staged:
+
+```bash
+git add <path>  # explicit path only, never -A or .
+```
+
+**If changing flake inputs, update the lockfile:**
+
+```bash
+nix flake update
+```
+
+## Verification
+
+Read `flake.nix` to discover the current set of `nixosConfigurations`. Evaluate each before claiming a change is correct.
+
+WSL requires `--impure` because its configuration references `/etc/nixos/corp.pem` via `builtins.pathExists`:
+
+```bash
+nix eval .#nixosConfigurations.<host>.config.system.build.toplevel.drvPath
+nix eval .#nixosConfigurations.WSL.config.system.build.toplevel.drvPath --impure
+```
+
+For changed packages, also build the derivation directly to isolate failures:
+
+```bash
+nix build --no-link .#nixosConfigurations.<host>.pkgs.<name>
+```
+
+## Runtime behaviour
+
+Behavioural changes that only manifest after `nixos-rebuild switch` cannot be agent-verified end-to-end. State this explicitly in the PR and propose the post-switch commands the user should run. Never claim "this fixes X" on the strength of a successful eval alone.
+
+## Style
+
+Prefer hoisting repeated literals (versions, hashes, URLs) into `let` bindings or attributes so they update in one place.

--- a/.agents/skills/nix-workflow/SKILL.md
+++ b/.agents/skills/nix-workflow/SKILL.md
@@ -1,17 +1,11 @@
 ---
 name: nix-workflow
-description: Use when editing any .nix files or making NixOS configuration changes in this repo
+description: Use when editing any .nix files in this repo, or when another skill needs nix verification steps
 ---
 
-# Nix Workflow
+## Visibility
 
-## Before making changes
-
-**Stage new `.nix` files immediately after writing them.** The flake uses the git tree as its source of truth — `nix eval`, `nix build`, and `nix flake check` cannot see untracked files. A new file produces `error: path '...' does not exist` until staged:
-
-```bash
-git add <path>  # explicit path only, never -A or .
-```
+The flake's **visibility** is the git index — only staged files are visible to `nix eval`, `nix build`, and `nix flake check`. Stage new `.nix` files immediately; untracked files produce `error: path '...' does not exist`.
 
 **If changing flake inputs, update the lockfile:**
 
@@ -21,7 +15,7 @@ nix flake update
 
 ## Verification
 
-Read `flake.nix` to discover the current set of `nixosConfigurations`. Evaluate each before claiming a change is correct.
+List `./nix/hosts/` to discover the current set of hosts. Evaluate each before claiming a change is correct.
 
 WSL requires `--impure` because its configuration references `/etc/nixos/corp.pem` via `builtins.pathExists`:
 
@@ -33,7 +27,7 @@ nix eval .#nixosConfigurations.WSL.config.system.build.toplevel.drvPath --impure
 For changed packages, also build the derivation directly to isolate failures:
 
 ```bash
-nix build --no-link .#nixosConfigurations.<host>.pkgs.<name>
+nix build --no-link --print-out-paths .#nixosConfigurations.<host>.pkgs.<name>
 ```
 
 ## Runtime behaviour

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,6 @@
 
 Before starting any task, review available skills and invoke any that apply.
 
----
-
 ## Golden Rules (MANDATORY)
 
 1. **Never work directly on `main`.** All work must happen in a worktree under `.worktrees/<branch>`.
@@ -15,14 +13,10 @@ Before starting any task, review available skills and invoke any that apply.
 7. **Never act on an unanswered question.** If you asked the user whether to proceed with something and no explicit answer was received — including across a context compaction boundary — re-ask before acting. A compaction summary does not constitute user consent.
 8. After a clean commit on a feature branch, push to `origin` and open a PR in the same turn.
 9. After a PR is confirmed merged, run `./scripts/agent-cleanup.sh <branch>` then `git pull` on `main`.
-
----
-
-## XDG Base Directory compliance
-
-Respect the XDG Base Directory specification for all tool configuration, data, and cache paths. Override non-compliant defaults where necessary.
-
----
+10. Respect the XDG Base Directory specification for all tool configuration, data, and cache paths. Override non-compliant defaults where necessary.
+11. Use `git commit --no-gpg-sign` when committing.
+12. Only comment to explain the non-obvious *why* — one line maximum, no restating what the code does.
+13. Root-cause analyses, falsified hypotheses, and link-outs to upstream issues belong in commit messages and PR bodies, not source comments.
 
 ## Never do
 
@@ -33,8 +27,6 @@ Respect the XDG Base Directory specification for all tool configuration, data, a
 - Never run destructive commands without explicit instruction.
 - Do not silently create more than one PR for the same branch.
 - Do not fabricate repository state; inspect it directly.
-
----
 
 ## Irreversible actions require explicit approval (MANDATORY)
 
@@ -50,15 +42,3 @@ Respect the XDG Base Directory specification for all tool configuration, data, a
 - Any read-only command (tests, linters, file reads)
 - `agent-cleanup.sh <branch>` + `git pull main` when user confirms a PR is merged
 
----
-
-## Environment
-
-GPG signing fails non-interactively (`gpg: cannot open '/dev/tty'`). Use `git commit --no-gpg-sign`.
-
----
-
-## Style
-
-- Only comment to explain the non-obvious *why* — one line maximum, no restating what the code does.
-- Root-cause analyses, falsified hypotheses, and link-outs to upstream issues belong in commit messages and PR bodies, not source comments.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,6 @@
-# AGENTS.md — Dotfiles + Nix Repo Agent Operating Manual
+# AGENTS.md
 
-This repository contains:
-- System dotfiles (shell/editor/tool configs)
-- Nix configuration for various systems under `nix/`
-- `flake.nix` and `flake.lock` at repository root
-
-This file is the source of truth for how coding agents must operate in this repo.
+Before starting any task, review available skills and invoke any that apply.
 
 ---
 
@@ -13,85 +8,24 @@ This file is the source of truth for how coding agents must operate in this repo
 
 1. **Never work directly on `main`.** All work must happen in a worktree under `.worktrees/<branch>`.
 2. **Always start work via:** `./scripts/agent-start.sh <branch>`
-3. **Commit messages MUST be Gitmoji + Conventional Commits:**
-   `<emoji> <type>(optional-scope): <description>`
-4. **Attribution rule:** agent-created commits MUST include a `Co-authored-by:` trailer identifying the AI agent (see [AI Co-Author Attribution](#ai-co-author-attribution-must)).
+3. **Commit messages must use gitmoji + conventional commits format.**
+4. **Every commit body must include `Co-authored-by: Copilot <copilot@github.com>`** — appended automatically by the worktree hook.
 5. Keep PRs small and reviewable. Prefer multiple atomic commits.
 6. Inspect git and GitHub state directly. Do not rely on pre-expanded shell snippets.
 7. **Never act on an unanswered question.** If you asked the user whether to proceed with something and no explicit answer was received — including across a context compaction boundary — re-ask before acting. A compaction summary does not constitute user consent.
+8. After a clean commit on a feature branch, push to `origin` and open a PR in the same turn.
+9. After a PR is confirmed merged, run `./scripts/agent-cleanup.sh <branch>` then `git pull` on `main`.
 
 ---
 
-## Worktree Workflow (MANDATORY)
+## XDG Base Directory compliance
 
-```bash
-# Create worktree + install hooks
-./scripts/agent-start.sh <branch>
-
-# Work inside the worktree (slashes in the branch name are preserved as
-# nested directories, e.g. branch "fix/foo-bar" → .worktrees/fix/foo-bar)
-cd .worktrees/<branch>
-
-# Push and open PR
-git push -u origin <branch>
-gh pr create --fill --base main
-```
-
-After a clean commit on a feature branch in a worktree, **push to `origin` and open the PR in the same turn**. Pushing a feature branch and opening a PR are not destructive and do not require explicit user approval. Wait for approval only for the actions listed under [Irreversible actions](#irreversible-actions-require-explicit-approval-mandatory).
-
-After a PR is merged, `./scripts/agent-cleanup.sh <branch>` removes the worktree, prunes worktree metadata, and deletes the local branch in one step. Then pull `main` to bring the local branch up to date. **Both steps are the agent's responsibility once the PR is confirmed merged**, but require user confirmation per the irreversible-actions rule.
-
----
-
-## Commit Message Standard (STRICT)
-
-Format: `<emoji> <type>(optional-scope): <description>`
-
-Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `build`, `perf`, `style`
-
-Examples:
-- `✨ feat(nix): add devShell for tooling`
-- `🔧 chore(dotfiles): add git aliases`
-- `🐛 fix(zsh): prevent duplicate PATH entries`
-
----
-
-## AI Co-Author Attribution (MUST)
-
-Every agent-created commit must include a `Co-authored-by:` trailer identifying the AI agent. **The commit-msg hook installed by `agent-start.sh` appends this automatically — you do not need to write it manually.**
-
-Default identity (when no env vars are set): `Co-authored-by: Copilot <copilot@github.com>`
-
-To use a different identity, set env vars before calling the script:
-
-```bash
-AI_COAUTHOR_NAME="My Agent" AI_COAUTHOR_EMAIL="agent@example.com" \
-  ./scripts/agent-start.sh <branch>
-```
-
-Rules:
-- Do not change the commit author identity to the AI identity.
-- Do not add additional co-authors unless explicitly requested.
-
----
-
-## Rules
-
-### Nix changes
-- Prefer minimal, reproducible changes.
-- Keep Nix-related edits within `nix/` where possible.
-- If you change flake outputs, ensure they remain consistent and valid.
-- If you change flake inputs, update the flake lockfile.
-- **Bumping a vendored package** (anything under `nix/pkgs/`): follow the recipe in [`.github/instructions/nix-version-bumps.instructions.md`](.github/instructions/nix-version-bumps.instructions.md). Read it before making changes.
-
-### Dotfiles changes
-- Keep changes scoped and minimal; avoid large refactors unless requested.
-- Do not introduce secrets (tokens, private keys, machine-specific secrets).
-
-### XDG Base Directory compliance
 Respect the XDG Base Directory specification for all tool configuration, data, and cache paths. Override non-compliant defaults where necessary.
 
-### Never do
+---
+
+## Never do
+
 - Never commit secrets, tokens, private keys, or `.env` files with secrets.
 - Never rewrite history on `main`.
 - Never use `git add -A` or `git add .`. Stage changes explicitly using file paths from status.
@@ -100,95 +34,31 @@ Respect the XDG Base Directory specification for all tool configuration, data, a
 - Do not silently create more than one PR for the same branch.
 - Do not fabricate repository state; inspect it directly.
 
-### Irreversible actions require explicit approval (MANDATORY)
+---
 
-Before executing any of the following actions, **state what you are about to do and
-wait for explicit confirmation in the current user message**. Generic phrases such as
-"continue", "proceed", or "go ahead with next steps" do NOT constitute approval.
+## Irreversible actions require explicit approval (MANDATORY)
 
-Actions that require explicit approval:
-- Merging a pull request (`gh pr merge`)
-- Running `nixos-rebuild switch` (activates a new system generation)
-- Any `git push` to `main`
+**Requires explicit approval** (state intent first — "proceed" / "continue" is not approval):
+- `gh pr merge`
+- `nixos-rebuild switch`
+- `git push` to `main`
 
-Actions that do **not** require explicit approval (do them and report — asking permission for these wastes a turn):
-- `git push` to a feature branch (anything except `main`)
+**No approval needed** (act and report):
+- `git push` / `git commit` / `git add <path>` on feature branches
 - `gh pr create` / `gh pr view` / `gh pr checks` / `gh pr diff`
-- Creating, reading, editing, or staging files inside a worktree
-- `git add <path>` (explicit paths only — never `-A` or `.`)
-- `git commit` on a feature branch
 - `nix eval` / `nix build --no-link` / `nix flake check` / `nix-prefetch-url`
-- Running tests, linters, formatters, or any read-only inspection command
-- `./scripts/agent-cleanup.sh <branch>` followed by `git pull` on `main` — when the user
-  states that a PR has been merged (e.g. "that PR is merged", "the PRs are merged"), that
-  statement is implicit approval to immediately run cleanup and pull main for the relevant
-  branch(es) without asking again.
+- Any read-only command (tests, linters, file reads)
+- `agent-cleanup.sh <branch>` + `git pull main` when user confirms a PR is merged
 
 ---
 
-## If uncertain
-Ask a short clarifying question rather than guessing. Follow existing patterns in this repo.
+## Environment
+
+GPG signing fails non-interactively (`gpg: cannot open '/dev/tty'`). Use `git commit --no-gpg-sign`.
 
 ---
 
-## Repo map
+## Style
 
-When a task touches files described in this map, read those files directly. Do **not** re-explore the tree with `ls`/`find`/`glob`/`grep` to confirm what the map already states. Only fall back to exploration if the task involves paths not covered here, or if you have specific reason to believe the map is out of date.
-
-| Path | Purpose |
-| --- | --- |
-| `flake.nix` / `flake.lock` | Flake entry. `nixosConfigurations`: `WSL`, `DansSpectre`, `New-H0Ryzen`. |
-| `nix/hosts/<host>/` | Per-host NixOS configuration (entrypoint: `configuration.nix`). |
-| `nix/home/` | Home-manager configuration shared across hosts. |
-| `nix/modules/{common,desktop,profiles}/` | Reusable NixOS modules composed by hosts. |
-| `nix/pkgs/` | Repo-local package derivations (e.g. `docker-sbx.nix`), exposed via `pkgs` overlay. |
-| `scripts/agent-start.sh` | Creates the per-branch worktree and installs the co-author hook. |
-| `scripts/agent-cleanup.sh` | Removes a merged branch's worktree and local branch in one step. |
-| `scripts/ai-commit` | Optional wrapper around `git commit` for agent commits. |
-| `.worktrees/<branch>/` | Active agent worktrees (slashes in the branch name are preserved as nested directories — `fix/foo` lives at `.worktrees/fix/foo`). Removed by `agent-cleanup.sh` after the user confirms the PR is merged. |
-
-Non-Nix dotfiles (shell, editor, tool configs) live at the repo root and under conventional `XDG_CONFIG_HOME` paths.
-
----
-
-## Environment facts
-
-- **Hosts:** the flake provides three NixOS configurations — `WSL` (NixOS-WSL2), `DansSpectre`, `New-H0Ryzen`. Detect the current host before assuming behaviour. The `$HOST` shell variable is the default way to read the hostname and can be used inline in commands (e.g. `nix build .#nixosConfigurations.$HOST...`). Fall back to `cat /etc/hostname` only if `$HOST` is unset.
-- **WSL-only specifics:** on `WSL` the kernel comes from the Windows side, not Nix; `/etc/nixos/corp.pem` may be present for the corporate CA (referenced via `builtins.pathExists`), which means rebuilds need `nixos-rebuild switch --flake .#WSL --impure`. These do not apply to `DansSpectre` or `New-H0Ryzen`.
-- **Working baselines for cross-distro debugging:** on `WSL` an Ubuntu/WSL2 install on the same Windows host is available as a side-by-side reference. On other hosts, compare against a previous working generation (`nix profile history`, `/run/current-system` vs the proposed build) instead.
-- **GPG signing fails non-interactively** (`gpg: cannot open '/dev/tty'`) in agent sessions. Use `git commit --no-gpg-sign` unless the user provides another path.
-- **GitHub:** `gh` is authenticated. Inspect PRs/issues/checks directly rather than guessing.
-
----
-
-## Verification expectations
-
-The flake uses the **git tree** as its source of truth. `nix eval`, `nix build`, and `nix flake check` cannot see untracked files — a newly written `.nix` file will produce a "path does not exist" error until it is staged. Stage new files with `git add <path>` (explicit paths only) immediately after writing them, before any `nix` evaluation or build.
-
-Before claiming a Nix change is correct:
-
-- `nix eval .#nixosConfigurations.<host>.config.system.build.toplevel.drvPath` must succeed.
-- For changed packages: `nix build .#nixosConfigurations.<host>.config.system.build.toplevel --no-link` (or build the specific derivation) must succeed.
-- Behavioural changes that only manifest after `nixos-rebuild switch` (services, kernel modules, runtime binaries) **cannot be agent-verified end-to-end**. State this explicitly in the PR and propose the post-switch commands the user should run.
-
-Never claim "this fixes X" on the strength of a successful eval alone when X is a runtime symptom.
-
----
-
-## Debugging discipline
-
-For non-trivial runtime failures (services crashing, packages misbehaving, mounts/perms issues), invoke the `systematic-debugging` skill before proposing a fix.
-
-- Treat the **first** ERROR in a log as the root cause candidate, not the most visible one. Downstream errors are often misleading (e.g. an `EACCES` mount error that's actually downstream of a segfaulting helper).
-- When a working baseline exists (other host running the same package, a parallel non-NixOS install, a previous generation), diff against it before hypothesising.
-- If the user reports a previous fix did not work, ask for the new failure mode before proposing the next change. Do not chain hypotheses without evidence.
-- Falsified hypotheses get recorded in the PR description / commit message so we don't re-run them next time.
-
----
-
-## Style notes
-
-- **Default: no comment.** Only add a comment when the code cannot convey the *why* on its own. If you are unsure whether a comment is needed, omit it.
-- When a comment is warranted, keep it to one line. Do not restate what the code does; explain only the non-obvious reason it does it.
-- Root-cause analyses, falsified hypotheses, and link-outs to upstream issues belong in commit messages and PR bodies, not in source comments.
-- Prefer hoisting repeated literals (versions, hashes, URLs) into `let` bindings or attributes so they update in one place.
+- Only comment to explain the non-obvious *why* — one line maximum, no restating what the code does.
+- Root-cause analyses, falsified hypotheses, and link-outs to upstream issues belong in commit messages and PR bodies, not source comments.

--- a/scripts/agent-start.sh
+++ b/scripts/agent-start.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # scripts/agent-start <branch>
 #
 # Creates a worktree at .worktrees/<branch> based on origin/main and
-# configures worktree-local hooks/helpers to ensure AI co-author attribution.
+# configures worktree-local hooks to ensure AI co-author attribution.
 #
 # Branch names containing slashes (e.g. "feat/foo") are preserved as nested
 # directories under .worktrees/ (e.g. .worktrees/feat/foo). Companion script
@@ -20,7 +20,6 @@ if [[ -z "${BRANCH}" ]]; then
 fi
 
 # --- configurable AI co-author trailer (override via env vars) ---
-# If you ever want OpenCode-specific attribution, change these defaults.
 AI_COAUTHOR_NAME="${AI_COAUTHOR_NAME:-Copilot}"
 AI_COAUTHOR_EMAIL="${AI_COAUTHOR_EMAIL:-copilot@github.com}"
 AI_TRAILER="Co-authored-by: ${AI_COAUTHOR_NAME} <${AI_COAUTHOR_EMAIL}>"
@@ -54,7 +53,7 @@ fi
 # Create the worktree and new branch from origin/main
 git worktree add -b "$BRANCH" "$TARGET_DIR" "origin/main"
 
-# Configure hook + helper scripts in the worktree only
+# Configure hook in the worktree only
 (
   cd "$TARGET_DIR"
 
@@ -66,7 +65,7 @@ EOF
   # Worktree-local hooks directory
   mkdir -p .githooks
 
-  # commit-msg hook: append trailer if missing
+  # commit-msg hook: append co-author trailer if missing
   cat > .githooks/commit-msg <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -89,49 +88,6 @@ EOF
 
   # Enable hooks for this worktree only
   git config core.hooksPath .githooks
-
-  # Helper script: explicit "agent commit" command
-  mkdir -p scripts
-  cat > scripts/ai-commit <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-
-if [[ $# -lt 1 ]]; then
-  echo "Usage: scripts/ai-commit \"<emoji> <type>(scope): message\""
-  exit 1
-fi
-
-MSG="$1"
-
-# Ensure staged changes exist
-if git diff --cached --quiet; then
-  echo "No staged changes. Stage files first (git add ...)."
-  exit 1
-fi
-
-# Commit with a title + trailer body.
-git commit -m "$MSG" -m "$(cat .ai-coauthor.txt)"
-EOF
-  chmod +x scripts/ai-commit
-
-  # Reminder doc
-  cat > .AI_WORKFLOW.md <<EOF
-# Worktree Workflow Reminder
-
-You are in a git worktree under \`.worktrees/\`.
-
-Rules:
-- Do NOT commit on main.
-- Commit format: \`<emoji> <type>(optional-scope): <description>\`
-- Agent commits MUST include:
-  ${AI_TRAILER}
-
-This worktree auto-appends the trailer via a local commit-msg hook.
-
-Common flow:
-  git add -A
-  scripts/ai-commit "✨ feat(nix): add devShell"
-EOF
 )
 
 echo ""
@@ -145,8 +101,7 @@ echo ""
 echo "Next steps:"
 echo "  1) cd \"$TARGET_DIR\""
 echo "  2) Make changes"
-echo "  3) Commit (either):"
-echo "       - scripts/ai-commit \"✨ feat(scope): message\""
-echo "       - or git commit (hook will append trailer automatically)"
-echo "  4) git push -u origin \"$BRANCH\""
-echo "  5) Open a PR to main"
+echo "  3) git add <explicit-paths>"
+echo "  4) git commit --no-gpg-sign -m \"✨ feat(scope): message\""
+echo "  5) git push -u origin \"$BRANCH\""
+echo "  6) Open a PR to main"


### PR DESCRIPTION
- Rewrote AGENTS.md: removed sections derivable from code (repo map,
  environment facts, verification steps, debugging discipline, worktree
  workflow code block, commit format detail, co-author detail)
- Condensed irreversible actions section by ~50%
- Added single skill auto-discovery instruction at top
- Stripped agent-start.sh to worktree creation + co-author hook only;
  removed ai-commit and .AI_WORKFLOW.md generation
- Converted nix-version-bumps.instructions.md to bump-nix-package skill
  under .agents/skills/ with self-contained content and dynamic host
  discovery from flake.nix
- Added nix-workflow skill covering stage-before-eval footgun, lockfile
  updates, host evaluation, WSL --impure, and runtime behaviour caveat
- Skills placed in .agents/skills/ for widest harness compatibility

Co-authored-by: Copilot <copilot@github.com>
