### PR TITLE
🔒 fix(doas): remove keepEnv to prevent root from inheriting user HOME

### DIFF
--- a/nix/modules/common/doas.nix
+++ b/nix/modules/common/doas.nix
@@ -23,7 +23,6 @@
         extraRules = [
           {
             groups = config.doas.adminGroups;
-            # keepEnv omitted: root must own its HOME/XDG dirs so nix never writes cache files as root into the invoking user's cache.
             persist = true;
           }
         ];

--- a/nix/modules/common/doas.nix
+++ b/nix/modules/common/doas.nix
@@ -23,7 +23,7 @@
         extraRules = [
           {
             groups = config.doas.adminGroups;
-            keepEnv = true;
+            # keepEnv omitted: root must own its HOME/XDG dirs so nix never writes cache files as root into the invoking user's cache.
             persist = true;
           }
         ];


### PR DESCRIPTION
## Problem

`keepEnv = true` in `doas.nix` passes `HOME=/home/dandyrow` into root processes. Because the repo sets `nix.settings.use-xdg-base-directories = true`, nix resolves its cache paths via `$HOME/.cache/nix/`. Running `doas nixos-rebuild switch` therefore writes cache files (e.g. `fetcher-cache-v4.sqlite`) into the invoking user's cache directory **as root**, making them unwritable on subsequent user-owned nix invocations.

## Fix

Remove `keepEnv = true` from the wheel rule. doas then sets `HOME=/root` for elevated processes, so nix cache writes land in root's own XDG dirs and never touch the user's cache.

The NixOS doas module unconditionally adds `setenv { SSH_AUTH_SOCK TERMINFO TERMINFO_DIRS }` to every rule regardless of `keepEnv`, so ssh-agent forwarding and terminal rendering in `doas nvim` are unaffected.

## Verification

All three hosts evaluate with `keepEnv = false`:

```
nix eval '.#nixosConfigurations.DansSpectre.config.security.doas.extraRules'
nix eval '.#nixosConfigurations.New-H0Ryzen.config.security.doas.extraRules'
nix eval '.#nixosConfigurations.WSL.config.security.doas.extraRules' --impure
```

## Post-switch check

After `doas nixos-rebuild switch`, confirm the fix by running:

```bash
doas nixos-rebuild switch --flake .#
nix flake show   # should succeed without permission errors
ls -la ~/.cache/nix/   # all files should be owned by dandyrow, not root
```
