### PR TITLE
🔒 fix(git): add safe.directory for dotfiles repo in /etc/gitconfig

### DIFF
--- a/nix/hosts/DansSpectre/configuration.nix
+++ b/nix/hosts/DansSpectre/configuration.nix
@@ -3,7 +3,6 @@
   documentation.nixos.enable = false;
 
   programs = {
-    git.enable = true;
     steam.enable = true;
   };
 

--- a/nix/hosts/New-H0Ryzen/configuration.nix
+++ b/nix/hosts/New-H0Ryzen/configuration.nix
@@ -15,7 +15,6 @@
   documentation.nixos.enable = false;
 
   programs = {
-    git.enable = true;
     steam.enable = true;
   };
 

--- a/nix/hosts/WSL/configuration.nix
+++ b/nix/hosts/WSL/configuration.nix
@@ -13,8 +13,6 @@
 
   documentation.nixos.enable = false;
 
-  programs.git.enable = true;
-
   # Corporate CA cert, manually placed at /etc/nixos/corp.pem (never committed).
   # Requires --impure; evaluates to [] when absent.
   security.pki.certificateFiles = lib.optionals (builtins.pathExists /etc/nixos/corp.pem) [

--- a/nix/modules/common/default.nix
+++ b/nix/modules/common/default.nix
@@ -25,4 +25,9 @@
   # (/nix/var/nix/profiles/per-user/root/channels) from being set up,
   # eliminating the warning about that path not existing during nixos-rebuild.
   nix.channel.enable = false;
+
+  programs.git = {
+    enable = true;
+    config = [ { safe.directory = "/home/dandyrow/.dotfiles"; } ];
+  };
 }


### PR DESCRIPTION
## Problem

A follow-up to #75. Removing `keepEnv` from doas means root now runs with `HOME=/root` instead of `HOME=/home/dandyrow`. libgit2 (used by nix internally to resolve flake git inputs) then rejects `/home/dandyrow/.dotfiles` via the [CVE-2022-24765](https://github.blog/2022-04-12-git-security-vulnerability-announced/) ownership check — the repo is owned by `dandyrow`, not `root`.

This breaks `doas nixos-rebuild switch --flake .#` with:
```
error: opening Git repository "/home/dandyrow/.dotfiles": repository path '/home/dandyrow/.dotfiles' is not owned by current user (libgit2 error code = 7)
```

## Fix

Add the dotfiles path to `programs.git.config` in the common module. This writes a `[safe] directory` entry to `/etc/gitconfig`, which is visible to root regardless of `HOME`, so libgit2 trusts the repo when elevated.

## Verification

```
nix eval '.#nixosConfigurations.DansSpectre.config.programs.git.config'
# => [ { } { safe = { directory = "/home/dandyrow/.dotfiles"; }; } ]
```

All three hosts evaluate cleanly.