### PR TITLE
🔧 fix(tmux): remove allow-passthrough

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,9 @@
           # Track a newer upstream than nixos-unstable currently ships; drop
           # this override when nixpkgs catches up.
           github-copilot-cli = final.callPackage ./nix/pkgs/github-copilot-cli.nix { };
+          # Track git master past 3.7b for DEC 2026 MODE_SYNC fixes (#4983, #5303).
+          # Drop when nixpkgs ships tmux 3.8 or a patched 3.7.x.
+          tmux = final.callPackage ./nix/pkgs/tmux.nix { };
         })
       ];
 

--- a/nix/pkgs/tmux.nix
+++ b/nix/pkgs/tmux.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  bison,
+  libevent,
+  ncurses,
+  pkg-config,
+  runCommand,
+  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
+  systemdLibs,
+  # broken on i686-linux https://github.com/tmux/tmux/issues/4597
+  withUtf8proc ? !(stdenv.hostPlatform.is32bit),
+  utf8proc,
+  withUtempter ? stdenv.hostPlatform.isLinux,
+  libutempter,
+  withSixel ? true,
+}:
+
+# Local override of nixpkgs' tmux to track git master past 3.7b.
+# Picks up fixes for three DEC 2026 (MODE_SYNC) bugs in 3.7b:
+#   - Structural commands not gated on MODE_SYNC (#4983)
+#   - Mouse mode re-asserted outside sync brackets on every redraw (#5303)
+#   - PR #5195 (nicm's patch in #4983 comment thread)
+# These cause cursor flickering in TUI apps (e.g. opencode) that use
+# \033[?2026h/l for synchronized output.
+# Delete this file and the overlay entry in flake.nix once nixpkgs ships
+# tmux 3.8 or a patched 3.7.x.
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tmux";
+  version = "3.7b-unstable-2026-07-09";
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "tmux";
+    repo = "tmux";
+    rev = "ec31f4566dca2315dee04c9c23834c0020a27b86";
+    hash = "sha256-LUmiKa8D22unaNNIDpWYpi5XsJzo/wKY44Vjeh357Fc=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+    bison
+  ];
+
+  buildInputs = [
+    ncurses
+    libevent
+  ]
+  ++ lib.optionals withSystemd [ systemdLibs ]
+  ++ lib.optionals withUtf8proc [ utf8proc ]
+  ++ lib.optionals withUtempter [ libutempter ];
+
+  configureFlags = [
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+  ]
+  ++ lib.optionals withSystemd [ "--enable-systemd" ]
+  ++ lib.optionals withSixel [ "--enable-sixel" ]
+  ++ lib.optionals withUtempter [ "--enable-utempter" ]
+  ++ lib.optionals withUtf8proc [ "--enable-utf8proc" ];
+
+  enableParallelBuilding = true;
+
+  passthru.terminfo = runCommand "tmux-terminfo" { nativeBuildInputs = [ ncurses ]; } ''
+    mkdir -p $out/share/terminfo/t
+    ln -sv ${ncurses}/share/terminfo/t/{tmux,tmux-256color,tmux-direct} $out/share/terminfo/t
+  '';
+
+  meta = {
+    homepage = "https://tmux.github.io/";
+    description = "Terminal multiplexer";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.unix;
+    mainProgram = "tmux";
+  };
+})

--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -6,7 +6,6 @@ set -g default-terminal "tmux-256color"
 set -as terminal-overrides ",*:Tc"
 
 set -g xterm-keys on
-set -g allow-passthrough on
 
 set -g base-index 1
 set -g pane-base-index 1

--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -4,6 +4,12 @@ bind C-Space send-prefix
 
 set -g default-terminal "tmux-256color"
 set -as terminal-overrides ",*:Tc"
+# Tell Windows Terminal (outer) it supports DEC 2026 sync — reduces frame flicker.
+# Workaround for tmux 3.7 MODE_SYNC bugs (#4983, #5303) fixed in master, not 3.7b.
+set -as terminal-features ",xterm*:sync"
+# Suppress tmux's own startup OSC 10/11 colour probes — responses leak into pane
+# stdin on slow connections or pane switches (tmux issue #4846).
+set -as terminal-features ",xterm*:ccolour@"
 
 set -g xterm-keys on
 

--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -4,12 +4,7 @@ bind C-Space send-prefix
 
 set -g default-terminal "tmux-256color"
 set -as terminal-overrides ",*:Tc"
-# Tell Windows Terminal (outer) it supports DEC 2026 sync — reduces frame flicker.
-# Workaround for tmux 3.7 MODE_SYNC bugs (#4983, #5303) fixed in master, not 3.7b.
-set -as terminal-features ",xterm*:sync"
-# Suppress tmux's own startup OSC 10/11 colour probes — responses leak into pane
-# stdin on slow connections or pane switches (tmux issue #4846).
-set -as terminal-features ",xterm*:ccolour@"
+set -as terminal-features ",xterm*:sync:ccolour@"
 
 set -g xterm-keys on
 


### PR DESCRIPTION
## What

Removes `set -g allow-passthrough on` from `tmux.conf`.

## Why

`allow-passthrough` was the root cause of OSC color-query responses being injected as keystrokes when switching panes (tracked in [map #77](https://github.com/dandyrow/dotfiles/issues/77)). When an app inside tmux sends a DCS passthrough probe (`\ePtmux;...\e\\`), tmux forwards it to Windows Terminal, which responds via stdin. tmux has no mechanism to route that response back to the requesting pane — it leaks into pane input on mouse clicks.

## Test after switching

After `doas nixos-rebuild switch --flake .#` and reloading tmux config (`prefix + r`), test in this order:

**1. Verify the pane injection is fixed:**
```bash
# In one pane, run:
cat -v
# In another pane, open opencode, then click back to the cat pane.
# Expected: nothing appears. Before this fix, rgb: color fragments would appear.
```

**2. Test neovim image previews (the key question):**
Open neovim and trigger your image preview plugin as you normally would.
- If previews **still work** → `allow-passthrough` was not needed. This PR is the complete fix.
- If previews **no longer work** → the plugin requires DCS passthrough. Revert this and we explore alternatives (sixel support, a different plugin backend, or a targeted passthrough approach).