### PR TITLE
🐛 fix(nix): let copilot-cli use the system trust store

### DIFF
--- a/nix/pkgs/github-copilot-cli.nix
+++ b/nix/pkgs/github-copilot-cli.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   autoPatchelfHook,
-  cacert,
   fetchurl,
   glib,
   libsecret,
@@ -69,11 +68,12 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postInstall = ''
+    # No SSL_CERT_DIR/SSL_CERT_FILE pin: the bundled Rust (rustls) runtime falls
+    # back to the system trust store, so custom/corporate CAs are honoured.
     makeWrapper ${nodejs}/bin/node "$out"/bin/copilot \
       --add-flag "$out"/lib/github-copilot-cli/index.js \
       --add-flag --no-auto-update \
       --set-default NODE_NO_WARNINGS 1 \
-      --set-default SSL_CERT_DIR ${cacert}/etc/ssl/certs \
       --prefix PATH : "${lib.makeBinPath [ bash ]}"
   '';
 

--- a/nix/pkgs/github-copilot-cli.nix
+++ b/nix/pkgs/github-copilot-cli.nix
@@ -68,8 +68,6 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postInstall = ''
-    # No SSL_CERT_DIR/SSL_CERT_FILE pin: the bundled Rust (rustls) runtime falls
-    # back to the system trust store, so custom/corporate CAs are honoured.
     makeWrapper ${nodejs}/bin/node "$out"/bin/copilot \
       --add-flag "$out"/lib/github-copilot-cli/index.js \
       --add-flag --no-auto-update \


### PR DESCRIPTION
## Problem

After upgrading `github-copilot-cli` 1.0.60 → 1.0.70, every HTTPS call fails with certificate errors on a machine behind a corporate TLS-intercepting proxy:

- `Error: Failed to load models … api.enterprise.githubcopilot.com … invalid peer certificate: UnknownIssuer`
- `failed to initialize MCP client … StreamableHttpClientWorker … https://mcp.figma.com/mcp`

## Root cause

Copilot's failing network calls do **not** go through Node — they go through a bundled Rust runtime (`runtime.node` = `reqwest` + `rustls-native-certs`). Left alone, that runtime falls back to `/etc/ssl/certs/ca-certificates.crt`, the NixOS system bundle, which includes CAs added via `security.pki` (the corporate CA in `/etc/nixos/corp.pem`).

The wrapper pinned `SSL_CERT_DIR` to the derivation's own `cacert` (plain upstream, 119 certs, **no** corporate CA), overriding that fallback. The proxy's cert then chains to an untrusted issuer → rustls `UnknownIssuer`.

Evidence:
- System bundle `n9mc63k…nss-cacert-3.125` = **122** certs (built with `… corp.pem`).
- Derivation's `cacert` `8pzhla2f…nss-cacert-3.125` = **119** certs.
- Pointing the runtime at the system bundle → connects. Pointing at the derivation cacert (via `SSL_CERT_FILE` **or** `SSL_CERT_DIR`) → `UnknownIssuer`. No cert env vars at all → connects (system fallback).

1.0.60 worked because it routed these calls through a stack that already used the system store; 1.0.70 moved them onto the pinned rustls path.

## Fix

Remove the `SSL_CERT_DIR` pin (and the now-unused `cacert` input) so the Rust runtime uses its natural system-trust-store fallback. No env var is set — the failing stack already does the right thing once we stop overriding it. Node's TLS stack isn't involved in the failing calls and is left untouched.

## Verification

- `nix build .#nixosConfigurations.New-H0Ryzen.pkgs.github-copilot-cli` — builds.
- WSL toplevel evaluates cleanly. (DansSpectre / New-H0Ryzen toplevel eval fails at an unrelated pre-existing `catppuccin-firefox` IFD build, identical on `main`.)
- Manual: invoking the CLI without the cert pin connects to the models API and MCP servers successfully.

## Post-switch check (agent cannot verify end-to-end)

After `nixos-rebuild switch`, confirm:

```
copilot -p "hi"          # should reply, no "Failed to load models"
copilot mcp list          # figma/context7 reachable in a session
```