### PR TITLE
🐛 fix(wsl): trust corporate CA in FOD build sandboxes

### DIFF
--- a/nix/hosts/WSL/configuration.nix
+++ b/nix/hosts/WSL/configuration.nix
@@ -19,9 +19,8 @@
     /etc/nixos/corp.pem
   ];
 
-  # NIX_SSL_CERT_FILE is the only cert var in fetchers' impureEnvVars allowlist,
-  # so it is the only way the corporate CA reaches FOD build sandboxes (e.g.
-  # fetchCargoVendor's crates.io fetch) behind the TLS-intercepting proxy.
+  # Required to allow build verification of other systems which aren't behind corp
+  # on this system
   systemd.services.nix-daemon.environment.NIX_SSL_CERT_FILE =
     lib.mkIf (builtins.pathExists /etc/nixos/corp.pem) "/etc/ssl/certs/ca-certificates.crt";
 

--- a/nix/hosts/WSL/configuration.nix
+++ b/nix/hosts/WSL/configuration.nix
@@ -19,6 +19,12 @@
     /etc/nixos/corp.pem
   ];
 
+  # NIX_SSL_CERT_FILE is the only cert var in fetchers' impureEnvVars allowlist,
+  # so it is the only way the corporate CA reaches FOD build sandboxes (e.g.
+  # fetchCargoVendor's crates.io fetch) behind the TLS-intercepting proxy.
+  systemd.services.nix-daemon.environment.NIX_SSL_CERT_FILE =
+    lib.mkIf (builtins.pathExists /etc/nixos/corp.pem) "/etc/ssl/certs/ca-certificates.crt";
+
   # Lets docker-sbx's Go cgo shim and mkfs.erofs resolve /lib64/ld-linux at
   # runtime, avoiding patchelf (which corrupts Go binaries' PT_LOAD layout).
   programs.nix-ld = {


### PR DESCRIPTION
## Problem

Building/evaluating the desktop host configs (DansSpectre, New-H0Ryzen) **from WSL** fails whenever they pull an uncached Rust source build — here, the `catppuccin-firefox` theme's `whiskers` cargo-vendor step:

```
CERTIFICATE_VERIFY_FAILED: unable to get local issuer certificate
https://static.crates.io/crates/deunicode/1.6.2/download
```

## Root cause

`fetchCargoVendor` downloads crates with Python `requests` inside a **fixed-output-derivation sandbox**. WSL sits behind a corporate TLS-intercepting proxy, so the fetcher must trust `/etc/nixos/corp.pem`. It doesn't, because of an env-var mismatch:

- The FOD's `impureEnvVars` allowlist forwards exactly one cert variable: **`NIX_SSL_CERT_FILE`**.
- The nix-daemon exports `CURL_CA_BUNDLE` (corp-inclusive) but **not** `NIX_SSL_CERT_FILE`, and `CURL_CA_BUNDLE` is not on the allowlist. So the sandbox fell back to a bundled plain `nss-cacert` with no corporate CA.

### Evidence (live `requests.get` to `static.crates.io` through the proxy)

| Env var set to corp bundle | Result |
|---|---|
| `NIX_SSL_CERT_FILE` | ✅ OK (nixpkgs patches `certifi` to honour it) |
| `CURL_CA_BUNDLE` | ✅ OK |
| `REQUESTS_CA_BUNDLE` | ✅ OK |
| `SSL_CERT_FILE` | ❌ fails |

Only `NIX_SSL_CERT_FILE` is *both* honoured by the fetcher *and* on the FOD allowlist.

## Fix

Set `NIX_SSL_CERT_FILE` on the nix-daemon (gated on `corp.pem` presence) to the corp-inclusive system bundle, so it's forwarded into every FOD build sandbox:

```nix
systemd.services.nix-daemon.environment.NIX_SSL_CERT_FILE =
  lib.mkIf (builtins.pathExists /etc/nixos/corp.pem) "/etc/ssl/certs/ca-certificates.crt";
```

Scope: **WSL only.** The two desktop hosts need no change — they build fine on non-proxied networks. This just unblocks building/evaluating them (and any Rust FOD) from WSL.

## Verification

- `nix eval .#nixosConfigurations.WSL.…nix-daemon.environment.NIX_SSL_CERT_FILE --impure` → `"/etc/ssl/certs/ca-certificates.crt"`.
- WSL toplevel evaluates cleanly (`--impure`).
- **Cannot be verified end-to-end without `nixos-rebuild switch`** — the daemon must restart to pick up the new environment.

## Post-switch check

```
nixos-rebuild switch --flake .#WSL --impure   # restarts nix-daemon
nix build .#nixosConfigurations.DansSpectre.config.system.build.toplevel   # should fetch crates via proxy and succeed
```