### PR TITLE
📝 docs(agents): harden the one-line comment rule

### DIFF
--- a/.agents/skills/nix-workflow/SKILL.md
+++ b/.agents/skills/nix-workflow/SKILL.md
@@ -37,3 +37,5 @@ Behavioural changes that only manifest after `nixos-rebuild switch` cannot be ag
 ## Style
 
 Prefer hoisting repeated literals (versions, hashes, URLs) into `let` bindings or attributes so they update in one place.
+
+Comments are one line, explaining a non-obvious *why* only. Put root-cause detail in the commit/PR, not the `.nix` file.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,16 @@ Before starting any task, review available skills and invoke any that apply.
 
 - Respect the XDG Base Directory specification for all tool configuration, data, and cache paths. Override non-compliant defaults where necessary.
 - Only comment to explain the non-obvious *why* — one line maximum, no restating what the code does. If a comment could be replaced by reading the next line, delete it. Describing what a variable holds, what a function's parameters mean, or what a block achieves are all forbidden.
+  - Bad — multi-line, restates the code:
+    ```nix
+    # NIX_SSL_CERT_FILE is the only cert var in the impureEnvVars allowlist,
+    # so it is the only way the corporate CA reaches FOD build sandboxes
+    # (fetchCargoVendor's crates.io fetch) behind the TLS-intercepting proxy.
+    ```
+  - Good — one line, non-obvious *why* only:
+    ```nix
+    # Only cert var forwarded into FOD sandboxes — carries the corp CA past the proxy.
+    ```
 - Root-cause analyses, falsified hypotheses, and link-outs to upstream issues belong in commit messages and PR bodies, not source comments.
 
 ## Working with Git
@@ -16,6 +26,7 @@ The following rules describe how you should use git:
 - **Always start work via:** `./scripts/agent-start.sh <branch>`
 - Inspect git and GitHub state directly. Do not rely on pre-expanded shell snippets.
 - Use `git commit --no-gpg-sign` when committing.
+- Before staging, re-read the diff: every added comment must be a single line explaining a non-obvious *why* — trim any that are not.
 - **Commit messages must use gitmoji + conventional commits format.**
 - **Every commit body must include `Co-authored-by: Copilot <copilot@github.com>`** — appended automatically by the worktree hook.
 - After a clean commit on a feature branch, push to `origin` and open a PR in the same turn.
@@ -32,7 +43,7 @@ The following rules describe how you should use git:
 - Never act on an unanswered question, including across context compaction. Re-ask before acting.
 - Do not silently create more than one PR for the same branch.
 - Do not fabricate repository state; inspect it directly.
-- Create verbose comments over multiple lines.
+- Never create verbose comments over multiple lines.
 
 ## Irreversible actions require explicit approval (MANDATORY)
 


### PR DESCRIPTION
## Why

Follow-up to a review lapse: I wrote a 3-line comment despite the existing "one line maximum" rule, and only trimmed it when pushed. The rule existed; adherence didn't. These changes add teeth without adding much prose.

## Changes

1. **Worked before/after example** under the comment Golden Rule in `AGENTS.md` — the real 3-line NIX_SSL_CERT_FILE comment vs. its one-line replacement. Concrete examples get followed more reliably than abstract prose.
2. **Pre-staging self-check** in the git workflow: "Before staging, re-read the diff: every added comment must be a single line…" — a verification gate at the moment it matters.
3. **Mirror into `nix-workflow` skill's `## Style`** — the rule is now in-context when editing `.nix` files, not only at the top of AGENTS.md.
4. **Bug fix:** the `## Never do` entry read `- Create verbose comments over multiple lines.` (an instruction to *do* it) → now `- Never create verbose comments over multiple lines.`

Docs-only; no `.nix` changed, so no eval needed.