### PR TITLE
📝 docs(agents): document native wayfinding tracker operations

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -20,3 +20,24 @@ Create a GitHub issue.
 ## When a skill says "fetch the relevant ticket"
 
 Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+The `wayfinder` skill maps an effort as a **map issue** (`wayfinder:map`) with **child tickets**. GitHub's native sub-issue and issue-dependency features are used so the frontier renders visually in the tracker UI — `gh` has no first-class verbs for them, so drive them through `gh api`. The `<n>/dependencies/*` endpoints are undocumented but functional as of `gh` 2.96 / 2026-07.
+
+Both endpoints take the child's **database `id`** (integer), not its issue number, and must be passed with `-F` (typed) not `-f` (string), or the API returns `422 not of type integer`.
+
+- **Get a ticket's database id**: `gh api repos/dandyrow/dotfiles/issues/<number> --jq .id`
+- **Make a ticket a sub-issue of the map**:
+  `gh api --method POST repos/dandyrow/dotfiles/issues/<map>/sub_issues -F sub_issue_id=<child_db_id>`
+- **List a map's sub-issues**:
+  `gh api repos/dandyrow/dotfiles/issues/<map>/sub_issues --jq '.[] | "#\(.number) [\(.state)] \(.title)"'`
+- **Wire a blocking edge** (`<n>` is blocked by `<blocker>`):
+  `gh api --method POST repos/dandyrow/dotfiles/issues/<n>/dependencies/blocked_by -F issue_id=<blocker_db_id>`
+- **List what blocks a ticket**:
+  `gh api repos/dandyrow/dotfiles/issues/<n>/dependencies/blocked_by --jq '.[] | "#\(.number) \(.title)"'`
+- **Frontier query** — open `wayfinder:*` sub-issues that are unassigned and have no *open* blocker. There is no single query for "unblocked"; list the open children, then filter out any whose `blocked_by` list still contains an open issue:
+  `gh issue list --label wayfinder:research --label wayfinder:grilling --state open --json number,title,assignees`
+  then check each with the `blocked_by` list command above.
+
+The map body's summary sections (Decisions-so-far, Not yet specified, Out of scope) are edited with `gh issue edit <map> --body-file <file>`. Claiming a ticket is `gh issue edit <n> --add-assignee @me`.


### PR DESCRIPTION
## What

Adds a **Wayfinding operations** section to `docs/agents/issue-tracker.md` documenting how to express wayfinder maps on GitHub using **native** sub-issues and issue dependencies, driven through `gh api`.

## Why

While charting the [nix-native agent workflow map (#90)](https://github.com/dandyrow/dotfiles/issues/90), the relationships were first wired with body-text `Parent:`/`Blocked by:` conventions because `gh` has no first-class sub-issue verb. That was a premature fallback — the native REST endpoints work fine and render the frontier visually in the tracker UI. This captures the verified recipes so future sessions don't repeat the shortcut.

## Notes

- Records the `-F` vs `-f` integer gotcha (`sub_issue_id`/`issue_id` want the database `id`, not the issue number, passed as a typed field).
- The `dependencies/*` endpoints are undocumented but functional as of `gh` 2.96 / 2026-07.