### PR TITLE
✨ feat(agents): add nix-native dependency workflow spec

### DIFF
--- a/agents/.config/agents/nix-native-deps.md
+++ b/agents/.config/agents/nix-native-deps.md
@@ -1,6 +1,6 @@
 # Nix-native dependency workflow
 
-Machine-global guidance for every AI agent operating on these NixOS machines. Never modify the system in a way Nix can't reproduce. No global `npm i -g`, `pip install`, `cargo install`, `go install`, `curl | sh`, or any other imperative, out-of-Nix install. When you need a tool, either run it ephemerally through Nix or propose adding it to the Nix config — never install it imperatively.
+Machine-global guidance for every AI agent operating on these NixOS machines. When you need a system or CLI tool, run it ephemerally through Nix or propose adding it to the Nix config. Never satisfy a tool-need with an imperative, out-of-Nix install the system can't reproduce — the full blocked set is listed under *opencode hard-stops* below.
 
 This file is the source of truth for the workflow and is loaded outside any single repo. Repo-specific rules live in that repo's own `AGENTS.md`; this file never overrides them and they never restate it.
 
@@ -12,7 +12,7 @@ It does **not** govern **project-local language dependencies** — packages a pr
 
 ## The dependency decision ladder
 
-**Trigger:** an unmet tool-need — you reach for a system/CLI tool that isn't on `PATH`. Reaching for an **install-class command** (`npm i -g`, `pip install`, `pipx install`, `cargo install`, `go install`, `nix profile install`, `nix-env -i`, `curl … | sh`) to satisfy that need is the **named anti-pattern**; stop and walk the ladder instead.
+**Trigger:** an unmet tool-need — you reach for a system/CLI tool that isn't on `PATH`. Satisfying it with an **install-class command** — any imperative install that lands outside Nix (the enforced set is listed under *opencode hard-stops*; `nix profile install` and `nix-env -i` are the same anti-pattern in Nix clothing) — is the **anti-pattern**; stop and walk the ladder instead.
 
 1. **Discover.** Find which Nix package provides the tool with `nix-locate <binary>` (e.g. `nix-locate bin/rg`). This maps a missing command to its `nixpkgs` attribute.
 
@@ -26,7 +26,7 @@ It does **not** govern **project-local language dependencies** — packages a pr
      - **Never** `nix profile install` or `nix-env -i` — those imperatively mutate the user profile and are the anti-pattern in Nix clothing.
    - **Permanent — always *propose*, never install.** When a tool crosses into permanent territory, open the propose-a-config-edit path below. Meanwhile, **proceed ephemerally** so you're never blocked waiting on the proposal.
 
-4. **Not in nixpkgs.** If discovery turns up nothing, the tool isn't packaged. Don't fall back to an imperative install — **actively propose vendoring** it into the repo, invoking the `bump-nix-package` skill, which owns the mechanics of authoring/adding the derivation. Routing here is in scope; the derivation authoring is the skill's job.
+4. **Not in nixpkgs.** If discovery turns up nothing, the tool isn't packaged. Don't fall back to an imperative install — **propose vendoring** it into the repo, invoking the `bump-nix-package` skill, which owns the mechanics of authoring/adding the derivation. Routing here is in scope; the derivation authoring is the skill's job.
 
 ## The propose-a-config-edit path (permanent tools)
 
@@ -48,8 +48,6 @@ Guidance is the baseline, but on opencode the workflow is also **enforced**, so 
 1. **Primary — a `tool.execute.before` plugin** that inspects the bash command string and blocks matches by regex before execution.
 2. **Backstop — `permission.bash` deny rules** for the same commands, in case the plugin is bypassed.
 
-(`PATH`-shadow shims — replacing `npm`/`pip` on `PATH` with rejecting stubs — are **out of scope**; the two layers above are the whole mechanism.)
-
 **Block** (imperative, un-reproducible installs):
 
 - `npm i -g` / `npm install -g` (global npm)
@@ -62,6 +60,4 @@ Guidance is the baseline, but on opencode the workflow is also **enforced**, so 
 
 - `npm ci`
 - local `npm install` (no `-g`, inside a project)
-- `pip install -r <file>` **only** in an explicit command-string venv form (e.g. an explicit venv `pip` path or activated-venv invocation). Detecting a venv via environment variables was considered and **dropped as unreliable** — the allow-list keys on the visible command string, not on ambient env.
-
-Authoring the plugin, the deny rules, and the Nix wiring is the spec's **implementation** and is tracked separately; this file states what that enforcement must commit to.
+- `pip install -r <file>` **only** in an explicit command-string venv form (e.g. an explicit venv `pip` path or activated-venv invocation). The allow-list keys on the visible command string, not on ambient env.

--- a/agents/.config/agents/nix-native-deps.md
+++ b/agents/.config/agents/nix-native-deps.md
@@ -1,0 +1,67 @@
+# Nix-native dependency workflow
+
+Machine-global guidance for every AI agent operating on these NixOS machines. Never modify the system in a way Nix can't reproduce. No global `npm i -g`, `pip install`, `cargo install`, `go install`, `curl | sh`, or any other imperative, out-of-Nix install. When you need a tool, either run it ephemerally through Nix or propose adding it to the Nix config — never install it imperatively.
+
+This file is the source of truth for the workflow and is loaded outside any single repo. Repo-specific rules live in that repo's own `AGENTS.md`; this file never overrides them and they never restate it.
+
+## Scope
+
+This governs **system and CLI tools** — executables you'd reach for on the command line (formatters, linters, language servers, CLIs, interpreters needed as ambient tools).
+
+It does **not** govern **project-local language dependencies** — packages a project declares for itself (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`). Installing those into the project's own tree is normal and off the ladder: `npm ci`, `npm install <pkg>` in a project, `pip install -r requirements.txt` inside a project venv, `cargo build`, `go build`. The line: does the tool belong to *the machine/your session* (on the ladder) or to *the project you're working in* (off it)?
+
+## The dependency decision ladder
+
+**Trigger:** an unmet tool-need — you reach for a system/CLI tool that isn't on `PATH`. Reaching for an **install-class command** (`npm i -g`, `pip install`, `pipx install`, `cargo install`, `go install`, `nix profile install`, `nix-env -i`, `curl … | sh`) to satisfy that need is the **named anti-pattern**; stop and walk the ladder instead.
+
+1. **Discover.** Find which Nix package provides the tool with `nix-locate <binary>` (e.g. `nix-locate bin/rg`). This maps a missing command to its `nixpkgs` attribute.
+
+2. **Prefer a project environment.** If the project defines its own environment, use it rather than reaching to the machine: `nix develop` for a flake devShell, or `nix-shell shell.nix` for a legacy shell. (Note: `direnv` is not available here, so environments are entered explicitly, not auto-loaded.) Only climb past this rung when there's no project env to carry the tool.
+
+3. **Route: ephemeral vs. permanent.** Judge by a **blend of lifetime, benefit, and frequency** — how long you'll need it, how much it helps, how often it recurs. **Default to ephemeral.** A one-off or short-lived need stays ephemeral; a tool that is clearly recurring, broadly useful, and long-lived is a *permanent* candidate.
+
+   - **Ephemeral — act on it yourself.** Use the pinned registry (the `nixpkgs#` registry is pinned to the system `nixpkgs`, currently `26.11` — do not add a flake ref or version):
+     - `nix run nixpkgs#<pkg> -- <args>` for a single one-off invocation.
+     - `nix shell nixpkgs#<pkg>` to drop the tool onto `PATH` for several commands in this session.
+     - **Never** `nix profile install` or `nix-env -i` — those imperatively mutate the user profile and are the anti-pattern in Nix clothing.
+   - **Permanent — always *propose*, never install.** When a tool crosses into permanent territory, open the propose-a-config-edit path below. Meanwhile, **proceed ephemerally** so you're never blocked waiting on the proposal.
+
+4. **Not in nixpkgs.** If discovery turns up nothing, the tool isn't packaged. Don't fall back to an imperative install — **actively propose vendoring** it into the repo, invoking the `bump-nix-package` skill, which owns the mechanics of authoring/adding the derivation. Routing here is in scope; the derivation authoring is the skill's job.
+
+## The propose-a-config-edit path (permanent tools)
+
+When rung 3 or 4 marks a tool as permanent, you *propose* a Nix config edit — you never apply it as a side effect of the current task.
+
+- **Scope-routing — where the package goes:**
+  - **Default: user scope** — add to `home.packages` in `nix/home/default.nix`. This is the right home for almost every CLI tool.
+  - **System scope** — `environment.systemPackages` — only when the tool must live **outside the user session** (needed by root, by a systemd unit, at boot, or by all users). State the tipping test explicitly when you choose it: *this tool has to exist outside my interactive user session, so user scope can't reach it.*
+  - **Vendored** — `nix/pkgs/*.nix` — when the tool isn't in nixpkgs (rung 4), via `bump-nix-package`.
+
+- **Placement — where in the tree:** put the edit next to the **closest existing sibling** — the least-conditional, least-host-specific location that is still correct. If no correct shared spot exists, you may create a new `common` module rather than forcing it into a host- or profile-specific file.
+
+- **Artifact — how you propose it:** a **PR carrying the edit on its own dedicated branch**. Never fold the config edit into the branch of the task that surfaced the need — it gets its own branch and its own PR, reviewed on its own merits. Proceed ephemerally on your original task while the PR is pending.
+
+## opencode hard-stops (enforcement layer)
+
+Guidance is the baseline, but on opencode the workflow is also **enforced**, so the anti-pattern is blocked, not just discouraged. Two layers:
+
+1. **Primary — a `tool.execute.before` plugin** that inspects the bash command string and blocks matches by regex before execution.
+2. **Backstop — `permission.bash` deny rules** for the same commands, in case the plugin is bypassed.
+
+(`PATH`-shadow shims — replacing `npm`/`pip` on `PATH` with rejecting stubs — are **out of scope**; the two layers above are the whole mechanism.)
+
+**Block** (imperative, un-reproducible installs):
+
+- `npm i -g` / `npm install -g` (global npm)
+- bare `pip install` and `pipx install`
+- `cargo install`
+- `go install`
+- `curl … | sh` (and equivalent pipe-to-shell)
+
+**Allow** (legitimate, reproducible, or project-local):
+
+- `npm ci`
+- local `npm install` (no `-g`, inside a project)
+- `pip install -r <file>` **only** in an explicit command-string venv form (e.g. an explicit venv `pip` path or activated-venv invocation). Detecting a venv via environment variables was considered and **dropped as unreliable** — the allow-list keys on the visible command string, not on ambient env.
+
+Authoring the plugin, the deny rules, and the Nix wiring is the spec's **implementation** and is tracked separately; this file states what that enforcement must commit to.

--- a/agents/.config/agents/nix-native-deps.md
+++ b/agents/.config/agents/nix-native-deps.md
@@ -1,52 +1,53 @@
 # Nix-native dependency workflow
 
-Machine-global guidance for every AI agent operating on these NixOS machines. When you need a system or CLI tool, run it ephemerally through Nix or propose adding it to the Nix config. Never satisfy a tool-need with an imperative, out-of-Nix install the system can't reproduce — the full blocked set is listed under *opencode hard-stops* below.
-
-This file is the source of truth for the workflow and is loaded outside any single repo. Repo-specific rules live in that repo's own `AGENTS.md`; this file never overrides them and they never restate it.
+Machine-global guidance for every AI agent operating on this NixOS machine. When you need a system or CLI tool, run it ephemerally through Nix or propose adding it to the Nix config. Never satisfy a tool-need with an imperative, out-of-Nix install the system can't reproduce. The full blocked set is listed under *opencode hard-stops* below.
 
 ## Scope
 
-This governs **system and CLI tools** — executables you'd reach for on the command line (formatters, linters, language servers, CLIs, interpreters needed as ambient tools).
+This governs **system and CLI tools**, executables you'd reach for on the command line (formatters, linters, language servers, CLIs, interpreters needed as ambient tools).
 
-It does **not** govern **project-local language dependencies** — packages a project declares for itself (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`). Installing those into the project's own tree is normal and off the ladder: `npm ci`, `npm install <pkg>` in a project, `pip install -r requirements.txt` inside a project venv, `cargo build`, `go build`. The line: does the tool belong to *the machine/your session* (on the ladder) or to *the project you're working in* (off it)?
+It does **not** govern **project-local language dependencies**, packages a project declares for itself (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`). Installing those into the project's own tree is normal and off the ladder: `npm ci`, `npm install <pkg>` in a project, `pip install -r requirements.txt` inside a project venv, `cargo build`, `go build`. The line: does the tool belong to *the machine/your session* (on the ladder) or to *the project you're working in* (off the ladder)?
 
 ## The dependency decision ladder
 
-**Trigger:** an unmet tool-need — you reach for a system/CLI tool that isn't on `PATH`. Satisfying it with an **install-class command** — any imperative install that lands outside Nix (the enforced set is listed under *opencode hard-stops*; `nix profile install` and `nix-env -i` are the same anti-pattern in Nix clothing) — is the **anti-pattern**; stop and walk the ladder instead.
+**Trigger:** an unmet tool-need. You reach for a system/CLI tool that isn't on `PATH`. This includes any imperative install that lands outside Nix (the enforced set is listed under *opencode hard-stops*; `nix profile install` and `nix-env -i` are the same anti-pattern in Nix clothing). Instead of installing imperatively stop and walk the ladder.
 
 1. **Discover.** Find which Nix package provides the tool with `nix-locate <binary>` (e.g. `nix-locate bin/rg`). This maps a missing command to its `nixpkgs` attribute.
 
 2. **Prefer a project environment.** If the project defines its own environment, use it rather than reaching to the machine: `nix develop` for a flake devShell, or `nix-shell shell.nix` for a legacy shell. (Note: `direnv` is not available here, so environments are entered explicitly, not auto-loaded.) Only climb past this rung when there's no project env to carry the tool.
 
-3. **Route: ephemeral vs. permanent.** Judge by a **blend of lifetime, benefit, and frequency** — how long you'll need it, how much it helps, how often it recurs. **Default to ephemeral.** A one-off or short-lived need stays ephemeral; a tool that is clearly recurring, broadly useful, and long-lived is a *permanent* candidate.
+3. **Route: ephemeral vs. permanent.** Judge by how long you'll need it, how much it helps and how often it recurs. **Default to ephemeral.** A one-off or short-lived need stays ephemeral whereas a tool that is clearly recurring, broadly useful, and long-lived is a *permanent* candidate.
 
-   - **Ephemeral — act on it yourself.** Use the pinned registry (the `nixpkgs#` registry is pinned to the system `nixpkgs`, currently `26.11` — do not add a flake ref or version):
+   - **Ephemeral, act on it yourself.** Use the pinned version of nixpkgs from the system's flake:
      - `nix run nixpkgs#<pkg> -- <args>` for a single one-off invocation.
      - `nix shell nixpkgs#<pkg>` to drop the tool onto `PATH` for several commands in this session.
-     - **Never** `nix profile install` or `nix-env -i` — those imperatively mutate the user profile and are the anti-pattern in Nix clothing.
-   - **Permanent — always *propose*, never install.** When a tool crosses into permanent territory, open the propose-a-config-edit path below. Meanwhile, **proceed ephemerally** so you're never blocked waiting on the proposal.
+     - **Never** `nix profile install` or `nix-env -i`. Those imperatively mutate the user profile and are the anti-pattern in Nix clothing.
+   - **Permanent, always *propose*, never install.** When a tool crosses into permanent territory, open the propose-a-config-edit path below. Meanwhile, **proceed ephemerally** so you're never blocked waiting on the proposal.
 
-4. **Not in nixpkgs.** If discovery turns up nothing, the tool isn't packaged. Don't fall back to an imperative install — **propose vendoring** it into the repo, invoking the `bump-nix-package` skill, which owns the mechanics of authoring/adding the derivation. Routing here is in scope; the derivation authoring is the skill's job.
+4. **Not in nixpkgs.** If discovery turns up nothing, the tool isn't packaged. Don't fall back to an imperative install. The tool becomes a **vendoring proposal** on the propose-a-config-edit path below, which owns the routing for the not-in-nixpkgs case.
 
 ## The propose-a-config-edit path (permanent tools)
 
-When rung 3 or 4 marks a tool as permanent, you *propose* a Nix config edit — you never apply it as a side effect of the current task.
+When rung 3 or 4 marks a tool as permanent, you *propose* a Nix config edit. You never *apply* it as a side effect of the current task.
 
-- **Scope-routing — where the package goes:**
-  - **Default: user scope** — add to `home.packages` in `nix/home/default.nix`. This is the right home for almost every CLI tool.
-  - **System scope** — `environment.systemPackages` — only when the tool must live **outside the user session** (needed by root, by a systemd unit, at boot, or by all users). State the tipping test explicitly when you choose it: *this tool has to exist outside my interactive user session, so user scope can't reach it.*
-  - **Vendored** — `nix/pkgs/*.nix` — when the tool isn't in nixpkgs (rung 4), via `bump-nix-package`.
+Every proposal targets the machine's Nix config at **`~/.dotfiles`**, a fixed location independent of whatever repo your current task is in. The paths below (`nix/home/default.nix`, `nix/pkgs/`) are relative to it. What *proposing* means depends on where you're working:
 
-- **Placement — where in the tree:** put the edit next to the **closest existing sibling** — the least-conditional, least-host-specific location that is still correct. If no correct shared spot exists, you may create a new `common` module rather than forcing it into a host- or profile-specific file.
+- **Already inside `~/.dotfiles`:** open the edit as a **PR on its own dedicated branch**, never folded into the branch of the task that surfaced the need. The branching and commit mechanics are governed by `~/.dotfiles`'s own `AGENTS.md`, which loads when you're in that repo.
+- **In any other repo:** do **not** reach into `~/.dotfiles` to open a PR as a side effect of unrelated work. Instead **surface the proposal** by naming the tool, the scope you'd choose, and the exact target path, so it can be carried into a `~/.dotfiles` session. Proceed ephemerally meanwhile.
 
-- **Artifact — how you propose it:** a **PR carrying the edit on its own dedicated branch**. Never fold the config edit into the branch of the task that surfaced the need — it gets its own branch and its own PR, reviewed on its own merits. Proceed ephemerally on your original task while the PR is pending.
+- **Scope-routing, where the package goes:**
+  - **Default: user scope.** Add to `home.packages` in `nix/home/default.nix`. This is the right home for almost every CLI tool.
+  - **System scope** (`environment.systemPackages`), only when the tool must live **outside the user session** (needed by root, by a systemd unit, at boot, or by all users). State the tipping test explicitly when you choose it: *this tool has to exist outside my interactive user session, so user scope can't reach it.*
+  - **Vendored** (`nix/pkgs/*.nix`), when the tool isn't in nixpkgs (rung 4), via `bump-nix-package`.
+
+- **Placement, where in the tree:** put the edit next to the **closest existing sibling**, the least-conditional, least-host-specific location that is still correct. If no correct shared spot exists, you may create a new `common` module rather than forcing it into a host- or profile-specific file.
 
 ## opencode hard-stops (enforcement layer)
 
 Guidance is the baseline, but on opencode the workflow is also **enforced**, so the anti-pattern is blocked, not just discouraged. Two layers:
 
-1. **Primary — a `tool.execute.before` plugin** that inspects the bash command string and blocks matches by regex before execution.
-2. **Backstop — `permission.bash` deny rules** for the same commands, in case the plugin is bypassed.
+1. **Primary, a `tool.execute.before` plugin** that inspects the bash command string and blocks matches by regex before execution.
+2. **Backstop, `permission.bash` deny rules** for the same commands, in case the plugin is bypassed.
 
 **Block** (imperative, un-reproducible installs):
 
@@ -54,7 +55,7 @@ Guidance is the baseline, but on opencode the workflow is also **enforced**, so 
 - bare `pip install` and `pipx install`
 - `cargo install`
 - `go install`
-- `curl … | sh` (and equivalent pipe-to-shell)
+- `curl ... | sh` (and equivalent pipe-to-shell)
 
 **Allow** (legitimate, reproducible, or project-local):
 

--- a/agents/.config/agents/nix-native-deps.md
+++ b/agents/.config/agents/nix-native-deps.md
@@ -1,18 +1,18 @@
 # Nix-native dependency workflow
 
-Machine-global guidance for every AI agent operating on this NixOS machine. When you need a system or CLI tool, run it ephemerally through Nix or propose adding it to the Nix config. Never satisfy a tool-need with an imperative, out-of-Nix install the system can't reproduce. The full *denylist* is below.
+Machine-global guidance for every AI agent operating on this NixOS machine. When you need a system or CLI tool, run it ephemerally through Nix or propose adding it to the Nix config. Never satisfy a tool-need with an imperative, out-of-Nix install the system can't reproduce.
 
 ## Scope
 
 This governs **system and CLI tools**, executables you'd reach for on the command line (formatters, linters, language servers, CLIs, interpreters needed as ambient tools).
 
-It does **not** govern **project-local language dependencies**, packages a project declares for itself (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`) and installs into its own tree. That's normal, and off the ladder. The line: does the tool belong to *the machine/your session* (on the ladder) or to *the project you're working in* (off the ladder)?
+It does **not** govern **project-local language dependencies**, packages a project declares for itself (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`) and installs into its own tree. The line: does the tool belong to *the machine/your session* (on the ladder) or to *the project you're working in* (off the ladder)?
 
 ## The dependency decision ladder
 
 **Trigger:** an unmet tool-need. You reach for a system/CLI tool that isn't on `PATH`. This includes any imperative install that lands outside Nix (see the *denylist* below). Instead of installing imperatively stop and walk the ladder.
 
-1. **Discover.** Find which Nix package provides the tool with `nix-locate <binary>` (e.g. `nix-locate bin/rg`). This maps a missing command to its `nixpkgs` attribute.
+1. **Discover.** Find which Nix package provides the tool with `nix-locate <binary>` (e.g. `nix-locate bin/rg`). This maps a missing command to its `nixpkgs` attribute. If discovery turns up nothing the tool isn't packaged: don't fall back to an imperative install, it becomes a **vendoring proposal** on the proposal path below, which owns the not-in-nixpkgs case.
 
 2. **Prefer a project environment.** If the project defines its own environment, use it rather than reaching to the machine: `nix develop` for a flake devShell, or `nix-shell shell.nix` for a legacy shell. (Note: `direnv` is not available here, so environments are entered explicitly, not auto-loaded.) Only climb past this rung when there's no project env to carry the tool.
 
@@ -21,16 +21,14 @@ It does **not** govern **project-local language dependencies**, packages a proje
    - **Ephemeral, act on it yourself.** Use the pinned version of nixpkgs from the system's flake:
      - `nix run nixpkgs#<pkg> -- <args>` for a single one-off invocation.
      - `nix shell nixpkgs#<pkg>` to drop the tool onto `PATH` for several commands in this session.
-     - **Never** `nix profile install` or `nix-env -i` (imperative profile mutation, on the *denylist*).
-   - **Permanent, always *propose*, never install.** When a tool crosses into permanent territory, open the propose-a-config-edit path below. Meanwhile, **proceed ephemerally** so you're never blocked waiting on the proposal.
+     - **Never** `nix profile install` or `nix-env -i` (on the *denylist*).
+   - **Permanent, always *propose*, never install.** When a tool crosses into permanent territory, open the proposal path below. Meanwhile, **proceed ephemerally** so you're never blocked waiting on the proposal.
 
-4. **Not in nixpkgs.** If discovery turns up nothing, the tool isn't packaged. Don't fall back to an imperative install. The tool becomes a **vendoring proposal** on the propose-a-config-edit path below, which owns the routing for the not-in-nixpkgs case.
+## The proposal path (permanent tools)
 
-## The propose-a-config-edit path (permanent tools)
+When rung 1 or 3 marks a tool as permanent, you *propose* a Nix config edit. You never *apply* it as a side effect of the current task.
 
-When rung 3 or 4 marks a tool as permanent, you *propose* a Nix config edit. You never *apply* it as a side effect of the current task.
-
-Every proposal targets the machine's Nix config at **`~/.dotfiles`**, a fixed location independent of whatever repo your current task is in. The paths below (`nix/home/default.nix`, `nix/pkgs/`) are relative to it. What *proposing* means depends on where you're working:
+Every proposal targets the machine's Nix config at **`~/.dotfiles`**. The paths below (`nix/home/default.nix`, `nix/pkgs/`) are relative to it. What *proposing* means depends on where you're working:
 
 - **Already inside `~/.dotfiles`:** open the edit as a **PR on its own dedicated branch**, never folded into the branch of the task that surfaced the need. The branching and commit mechanics are governed by `~/.dotfiles`'s own `AGENTS.md`, which loads when you're in that repo.
 - **In any other repo:** do **not** reach into `~/.dotfiles` to open a PR as a side effect of unrelated work. Instead **surface the proposal** by naming the tool, the scope you'd choose, and the exact target path, so it can be carried into a `~/.dotfiles` session.
@@ -38,13 +36,13 @@ Every proposal targets the machine's Nix config at **`~/.dotfiles`**, a fixed lo
 - **Scope-routing, where the package goes:**
   - **Default: user scope.** Add to `home.packages` in `nix/home/default.nix`. This is the right home for almost every CLI tool.
   - **System scope** (`environment.systemPackages`), only when the tool must live **outside the user session** (needed by root, by a systemd unit, at boot, or by all users). State the reason for system scope explicitly when you choose it: *this tool has to exist outside my interactive user session, so user scope can't reach it.*
-  - **Vendored** (`nix/pkgs/*.nix`), when the tool isn't in nixpkgs (rung 4), via `bump-nix-package` skill.
+  - **Vendored** (`nix/pkgs/*.nix`), when the tool isn't in nixpkgs (rung 1), via `bump-nix-package` skill.
 
 - **Placement, where in the tree:** put the edit next to the **closest existing sibling**, the least-conditional, least-host-specific location that is still correct. If no correct shared spot exists, you may create a new `common` module rather than forcing it into a host or profile specific file.
 
 ## Denylist and allowlist
 
-These are the imperative, un-reproducible installs the ladder exists to prevent, and the reproducible or project-local ones it leaves alone. Every agent on this machine must honour them as guidance.
+These are the imperative, un-reproducible installs the ladder exists to prevent, and the reproducible or project-local ones it leaves alone.
 
 **Denylist** (imperative, un-reproducible installs):
 

--- a/agents/.config/agents/nix-native-deps.md
+++ b/agents/.config/agents/nix-native-deps.md
@@ -1,27 +1,27 @@
 # Nix-native dependency workflow
 
-Machine-global guidance for every AI agent operating on this NixOS machine. When you need a system or CLI tool, run it ephemerally through Nix or propose adding it to the Nix config. Never satisfy a tool-need with an imperative, out-of-Nix install the system can't reproduce. The full blocked set is listed under *opencode hard-stops* below.
+Machine-global guidance for every AI agent operating on this NixOS machine. When you need a system or CLI tool, run it ephemerally through Nix or propose adding it to the Nix config. Never satisfy a tool-need with an imperative, out-of-Nix install the system can't reproduce. The full *denylist* is below.
 
 ## Scope
 
 This governs **system and CLI tools**, executables you'd reach for on the command line (formatters, linters, language servers, CLIs, interpreters needed as ambient tools).
 
-It does **not** govern **project-local language dependencies**, packages a project declares for itself (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`). Installing those into the project's own tree is normal and off the ladder: `npm ci`, `npm install <pkg>` in a project, `pip install -r requirements.txt` inside a project venv, `cargo build`, `go build`. The line: does the tool belong to *the machine/your session* (on the ladder) or to *the project you're working in* (off the ladder)?
+It does **not** govern **project-local language dependencies**, packages a project declares for itself (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`) and installs into its own tree. That's normal, and off the ladder. The line: does the tool belong to *the machine/your session* (on the ladder) or to *the project you're working in* (off the ladder)?
 
 ## The dependency decision ladder
 
-**Trigger:** an unmet tool-need. You reach for a system/CLI tool that isn't on `PATH`. This includes any imperative install that lands outside Nix (the enforced set is listed under *opencode hard-stops*; `nix profile install` and `nix-env -i` are the same anti-pattern in Nix clothing). Instead of installing imperatively stop and walk the ladder.
+**Trigger:** an unmet tool-need. You reach for a system/CLI tool that isn't on `PATH`. This includes any imperative install that lands outside Nix (see the *denylist* below). Instead of installing imperatively stop and walk the ladder.
 
 1. **Discover.** Find which Nix package provides the tool with `nix-locate <binary>` (e.g. `nix-locate bin/rg`). This maps a missing command to its `nixpkgs` attribute.
 
 2. **Prefer a project environment.** If the project defines its own environment, use it rather than reaching to the machine: `nix develop` for a flake devShell, or `nix-shell shell.nix` for a legacy shell. (Note: `direnv` is not available here, so environments are entered explicitly, not auto-loaded.) Only climb past this rung when there's no project env to carry the tool.
 
-3. **Route: ephemeral vs. permanent.** Judge by how long you'll need it, how much it helps and how often it recurs. **Default to ephemeral.** A one-off or short-lived need stays ephemeral whereas a tool that is clearly recurring, broadly useful, and long-lived is a *permanent* candidate.
+3. **Route: ephemeral vs. permanent.** **Default to ephemeral.** A one-off or short-lived need stays ephemeral; a tool that is clearly recurring, broadly useful, and long-lived is a *permanent* candidate.
 
    - **Ephemeral, act on it yourself.** Use the pinned version of nixpkgs from the system's flake:
      - `nix run nixpkgs#<pkg> -- <args>` for a single one-off invocation.
      - `nix shell nixpkgs#<pkg>` to drop the tool onto `PATH` for several commands in this session.
-     - **Never** `nix profile install` or `nix-env -i`. Those imperatively mutate the user profile and are the anti-pattern in Nix clothing.
+     - **Never** `nix profile install` or `nix-env -i` (imperative profile mutation, on the *denylist*).
    - **Permanent, always *propose*, never install.** When a tool crosses into permanent territory, open the propose-a-config-edit path below. Meanwhile, **proceed ephemerally** so you're never blocked waiting on the proposal.
 
 4. **Not in nixpkgs.** If discovery turns up nothing, the tool isn't packaged. Don't fall back to an imperative install. The tool becomes a **vendoring proposal** on the propose-a-config-edit path below, which owns the routing for the not-in-nixpkgs case.
@@ -33,32 +33,30 @@ When rung 3 or 4 marks a tool as permanent, you *propose* a Nix config edit. You
 Every proposal targets the machine's Nix config at **`~/.dotfiles`**, a fixed location independent of whatever repo your current task is in. The paths below (`nix/home/default.nix`, `nix/pkgs/`) are relative to it. What *proposing* means depends on where you're working:
 
 - **Already inside `~/.dotfiles`:** open the edit as a **PR on its own dedicated branch**, never folded into the branch of the task that surfaced the need. The branching and commit mechanics are governed by `~/.dotfiles`'s own `AGENTS.md`, which loads when you're in that repo.
-- **In any other repo:** do **not** reach into `~/.dotfiles` to open a PR as a side effect of unrelated work. Instead **surface the proposal** by naming the tool, the scope you'd choose, and the exact target path, so it can be carried into a `~/.dotfiles` session. Proceed ephemerally meanwhile.
+- **In any other repo:** do **not** reach into `~/.dotfiles` to open a PR as a side effect of unrelated work. Instead **surface the proposal** by naming the tool, the scope you'd choose, and the exact target path, so it can be carried into a `~/.dotfiles` session.
 
 - **Scope-routing, where the package goes:**
   - **Default: user scope.** Add to `home.packages` in `nix/home/default.nix`. This is the right home for almost every CLI tool.
-  - **System scope** (`environment.systemPackages`), only when the tool must live **outside the user session** (needed by root, by a systemd unit, at boot, or by all users). State the tipping test explicitly when you choose it: *this tool has to exist outside my interactive user session, so user scope can't reach it.*
-  - **Vendored** (`nix/pkgs/*.nix`), when the tool isn't in nixpkgs (rung 4), via `bump-nix-package`.
+  - **System scope** (`environment.systemPackages`), only when the tool must live **outside the user session** (needed by root, by a systemd unit, at boot, or by all users). State the reason for system scope explicitly when you choose it: *this tool has to exist outside my interactive user session, so user scope can't reach it.*
+  - **Vendored** (`nix/pkgs/*.nix`), when the tool isn't in nixpkgs (rung 4), via `bump-nix-package` skill.
 
-- **Placement, where in the tree:** put the edit next to the **closest existing sibling**, the least-conditional, least-host-specific location that is still correct. If no correct shared spot exists, you may create a new `common` module rather than forcing it into a host- or profile-specific file.
+- **Placement, where in the tree:** put the edit next to the **closest existing sibling**, the least-conditional, least-host-specific location that is still correct. If no correct shared spot exists, you may create a new `common` module rather than forcing it into a host or profile specific file.
 
-## opencode hard-stops (enforcement layer)
+## Denylist and allowlist
 
-Guidance is the baseline, but on opencode the workflow is also **enforced**, so the anti-pattern is blocked, not just discouraged. Two layers:
+These are the imperative, un-reproducible installs the ladder exists to prevent, and the reproducible or project-local ones it leaves alone. Every agent on this machine must honour them as guidance.
 
-1. **Primary, a `tool.execute.before` plugin** that inspects the bash command string and blocks matches by regex before execution.
-2. **Backstop, `permission.bash` deny rules** for the same commands, in case the plugin is bypassed.
-
-**Block** (imperative, un-reproducible installs):
+**Denylist** (imperative, un-reproducible installs):
 
 - `npm i -g` / `npm install -g` (global npm)
 - bare `pip install` and `pipx install`
 - `cargo install`
 - `go install`
 - `curl ... | sh` (and equivalent pipe-to-shell)
+- `nix profile install` / `nix-env -i` (imperative profile mutation, the anti-pattern in Nix clothing)
 
-**Allow** (legitimate, reproducible, or project-local):
+**Allowlist** (reproducible, or project-local):
 
 - `npm ci`
 - local `npm install` (no `-g`, inside a project)
-- `pip install -r <file>` **only** in an explicit command-string venv form (e.g. an explicit venv `pip` path or activated-venv invocation). The allow-list keys on the visible command string, not on ambient env.
+- `pip install -r <file>` **only** in an explicit command-string venv form (e.g. an explicit venv `pip` path or activated-venv invocation), keyed on the visible command string, not on ambient env.

--- a/agents/.config/agents/nix-native-deps.md
+++ b/agents/.config/agents/nix-native-deps.md
@@ -6,27 +6,27 @@ Machine-global guidance for every AI agent operating on this NixOS machine. When
 
 This governs **system and CLI tools**, executables you'd reach for on the command line (formatters, linters, language servers, CLIs, interpreters needed as ambient tools).
 
-It does **not** govern **project-local language dependencies**, packages a project declares for itself (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`) and installs into its own tree. The line: does the tool belong to *the machine/your session* (on the ladder) or to *the project you're working in* (off the ladder)?
+It does **not** govern **project-local language dependencies**, packages a project declares for itself (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`) and installs into its own tree. The line: does the tool belong to *the machine/your session* or to *the project you're working in*?
 
 ## The dependency decision ladder
 
-**Trigger:** an unmet tool-need. You reach for a system/CLI tool that isn't on `PATH`. This includes any imperative install that lands outside Nix (see the *denylist* below). Instead of installing imperatively stop and walk the ladder.
+**Trigger:** an unmet tool-need. You reach for a system/CLI tool that isn't on `PATH`. This includes any imperative install that lands outside Nix (see the *denylist* below). Instead of installing imperatively, stop and walk the ladder.
 
-1. **Discover.** Find which Nix package provides the tool with `nix-locate <binary>` (e.g. `nix-locate bin/rg`). This maps a missing command to its `nixpkgs` attribute. If discovery turns up nothing the tool isn't packaged: don't fall back to an imperative install, it becomes a **vendoring proposal** on the proposal path below, which owns the not-in-nixpkgs case.
+1. **Default to a project environment.** If the project defines its own environment, use it rather than reaching to the machine: `nix develop` for a flake devShell, or `nix-shell shell.nix` for a legacy shell. (Note: `direnv` is not available here, so environments are entered explicitly, not auto-loaded.) Only climb past this rung when there's no project env to carry the tool.
 
-2. **Prefer a project environment.** If the project defines its own environment, use it rather than reaching to the machine: `nix develop` for a flake devShell, or `nix-shell shell.nix` for a legacy shell. (Note: `direnv` is not available here, so environments are entered explicitly, not auto-loaded.) Only climb past this rung when there's no project env to carry the tool.
+2. **Discover.** Find which Nix package provides the tool with `nix-locate <binary>` (e.g. `nix-locate bin/rg`). This maps a missing command to its `nixpkgs` attribute. If discovery turns up nothing the tool isn't packaged: it's a **vendoring proposal** (proposal path below), do not fallback to an imperative install.
 
 3. **Route: ephemeral vs. permanent.** **Default to ephemeral.** A one-off or short-lived need stays ephemeral; a tool that is clearly recurring, broadly useful, and long-lived is a *permanent* candidate.
 
    - **Ephemeral, act on it yourself.** Use the pinned version of nixpkgs from the system's flake:
      - `nix run nixpkgs#<pkg> -- <args>` for a single one-off invocation.
      - `nix shell nixpkgs#<pkg>` to drop the tool onto `PATH` for several commands in this session.
-     - **Never** `nix profile install` or `nix-env -i` (on the *denylist*).
-   - **Permanent, always *propose*, never install.** When a tool crosses into permanent territory, open the proposal path below. Meanwhile, **proceed ephemerally** so you're never blocked waiting on the proposal.
+     - **Never** `nix profile install` or `nix-env -i`.
+   - **Permanent, *propose*** When a tool crosses into permanent territory, open the proposal path below. Meanwhile, **proceed ephemerally** so you're never blocked waiting on the proposal.
 
 ## The proposal path (permanent tools)
 
-When rung 1 or 3 marks a tool as permanent, you *propose* a Nix config edit. You never *apply* it as a side effect of the current task.
+When rung 2 or 3 marks a tool as permanent, you *propose* a Nix config edit. You never *apply* it as a side effect of the current task.
 
 Every proposal targets the machine's Nix config at **`~/.dotfiles`**. The paths below (`nix/home/default.nix`, `nix/pkgs/`) are relative to it. What *proposing* means depends on where you're working:
 
@@ -35,8 +35,8 @@ Every proposal targets the machine's Nix config at **`~/.dotfiles`**. The paths 
 
 - **Scope-routing, where the package goes:**
   - **Default: user scope.** Add to `home.packages` in `nix/home/default.nix`. This is the right home for almost every CLI tool.
-  - **System scope** (`environment.systemPackages`), only when the tool must live **outside the user session** (needed by root, by a systemd unit, at boot, or by all users). State the reason for system scope explicitly when you choose it: *this tool has to exist outside my interactive user session, so user scope can't reach it.*
-  - **Vendored** (`nix/pkgs/*.nix`), when the tool isn't in nixpkgs (rung 1), via `bump-nix-package` skill.
+  - **System scope** (`environment.systemPackages`), only when the tool must live **outside the user session** (needed by root, by a systemd unit, at boot, or by all users). State the reason for system scope explicitly when you choose it.
+  - **Vendored** (`nix/pkgs/*.nix`), when the tool isn't in nixpkgs (rung 2), via `bump-nix-package` skill.
 
 - **Placement, where in the tree:** put the edit next to the **closest existing sibling**, the least-conditional, least-host-specific location that is still correct. If no correct shared spot exists, you may create a new `common` module rather than forcing it into a host or profile specific file.
 


### PR DESCRIPTION
## Summary

Assembles the [wayfinder map's](https://github.com/dandyrow/dotfiles/issues/90) destination — a ready-to-implement, machine-global guidance spec at `agents/.config/agents/nix-native-deps.md` steering every AI agent toward a nix-native dependency workflow: run tools ephemerally via Nix, or propose adding them to the Nix config, never install imperatively.

Composed from the seven settled decision tickets:

- **Scope + facts** (#91–#93): flakes-enabled, pinned `nixpkgs#` registry, permanent scopes, feasibility of enforcement.
- **The dependency decision ladder** (#94): trigger, install-class anti-pattern, discovery → project-env → ephemeral/permanent routing → vendoring rung.
- **The propose-a-config-edit path** (#95): scope-routing, placement, dedicated-branch PR artifact.
- **The opencode hard-stops** (#96): block/allow lists for the `tool.execute.before` plugin + `permission.bash` backstop.
- **Global placement** (#99) + **`COPILOT_HOME` hardening** (#100): why this is its own file, separate from repo `AGENTS.md`.

## Out of scope (implementation hand-off)

Per the map's planning scope, this PR is the spec **only**. Still to implement and wire:

- Nix wiring: `mkConfigLink "agents"`, opencode `instructions`, copilot `copilot-instructions.md` symlink, `COPILOT_HOME`/`COPILOT_SKILLS_DIRS` moved to `environment.sessionVariables` (new `nix/modules/common/agents.nix`).
- Live enforcement: the `tool.execute.before` plugin + `permission.bash` deny rules.

Resolves #98.

Co-authored-by: Copilot <copilot@github.com>