### PR TITLE
✨ feat(opencode): load machine-global nix-native guidance

### DIFF
--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -93,6 +93,7 @@ in
     # On NixOS the clone is created during system activation (see modules/common/dotfiles.nix).
     # On non-NixOS the clone is created by the cloneDotfiles activation script below.
     file = lib.mkMerge [
+      (mkConfigLink "agents")
       (mkConfigLink "bat")
       (mkConfigLink "btop")
       (mkConfigLink "eza")

--- a/opencode/.config/opencode/opencode.json
+++ b/opencode/.config/opencode/opencode.json
@@ -10,6 +10,7 @@
   "skills": {
     "paths": ["~/.local/share/agents/skills"]
   },
+  "instructions": ["{env:HOME}/.config/agents/nix-native-deps.md"],
   "formatter": true,
   "autoupdate": false
 }


### PR DESCRIPTION
## What

Makes every opencode session — in **any** repo — automatically load the machine-global nix-native dependency guidance, wired declaratively via home-manager.

Two pieces:
- `nix/home/default.nix`: add `(mkConfigLink "agents")` so the tool-neutral `agents` config hub symlinks to `~/.config/agents`, and `~/.config/agents/nix-native-deps.md` resolves to the repo file (`agents/.config/agents/nix-native-deps.md`, merged in #101).
- `opencode/.config/opencode/opencode.json`: add `"instructions": ["{env:HOME}/.config/agents/nix-native-deps.md"]` so the global config loads the guidance.

The `agents/` hub is shared infrastructure — the copilot loader (#105) reuses the same symlink.

## Verification

- `nix eval` succeeds for all three hosts (DansSpectre, New-H0Ryzen, WSL `--impure`).
- `nix flake check --impure`: **all checks passed**.
- `opencode.json` is valid JSON.

### Runtime checks (require a rebuild — cannot be agent-verified)

After `nixos-rebuild switch` / home-manager activation, confirm:
- `readlink ~/.config/agents/nix-native-deps.md` resolves into the dotfiles repo.
- An opencode session started **outside** the dotfiles repo shows the nix-native guidance in context.
- Loading inside the dotfiles repo does not error on double-load.

## Notes

- The `instructions` value uses `{env:HOME}/.config/agents/...` exactly as the spec prescribes. Code review flagged the `{env:HOME}` vs the adjacent `skills.paths` `~` form as a minor style inconsistency, and a strict-XDG `{env:XDG_CONFIG_HOME}` alternative — both deferred to the spec's verbatim wording.

Closes #102