### PR TITLE
✨ feat(agents): set Copilot vars via NixOS sessionVariables

### DIFF
--- a/nix/modules/common/agents.nix
+++ b/nix/modules/common/agents.nix
@@ -1,0 +1,8 @@
+{ ... }:
+{
+  # $HOME-literal, not XDG vars: those are interactive-zsh-only, and NixOS rewrites $HOME to pam_env's @{HOME}.
+  environment.sessionVariables = {
+    COPILOT_HOME = "$HOME/.config/copilot";
+    COPILOT_SKILLS_DIRS = "$HOME/.local/share/agents/skills";
+  };
+}

--- a/nix/modules/common/agents.nix
+++ b/nix/modules/common/agents.nix
@@ -1,6 +1,7 @@
 { ... }:
 {
   # $HOME-literal, not XDG vars: those are interactive-zsh-only, and NixOS rewrites $HOME to pam_env's @{HOME}.
+  # Trade-off: pam_env covers login/PAM sessions but not system-level systemd units started outside one.
   environment.sessionVariables = {
     COPILOT_HOME = "$HOME/.config/copilot";
     COPILOT_SKILLS_DIRS = "$HOME/.local/share/agents/skills";

--- a/nix/modules/common/default.nix
+++ b/nix/modules/common/default.nix
@@ -9,6 +9,7 @@
     ./doas.nix
     ./gnupg.nix
     ./zsh.nix
+    ./agents.nix
   ];
 
   nix.settings = {

--- a/zsh/.config/zsh/.zshrc
+++ b/zsh/.config/zsh/.zshrc
@@ -35,8 +35,6 @@ export OLLAMA_MODELS="$XDG_DATA_HOME/ollama/models"
 export PYTHON_HISTORY="$XDG_STATE_HOME/python_history"
 export PYTHONPYCACHEPREFIX="$XDG_CACHE_HOME/python"
 export PYTHONUSERBASE="$XDG_DATA_HOME/python"
-export COPILOT_HOME="$XDG_CONFIG_HOME/copilot"
-export COPILOT_SKILLS_DIRS="$XDG_DATA_HOME/agents/skills"
 export DOCKER_CONFIG="$XDG_CONFIG_HOME/docker"
 
 # Source Home Manager session variables (adds ~/.nix-profile/bin to PATH,


### PR DESCRIPTION
## What

Makes `~/.config/copilot` authoritative for Copilot in every PAM/systemd session context, not just interactive zsh. Closes #103.

- New module `nix/modules/common/agents.nix` sets `COPILOT_HOME` and `COPILOT_SKILLS_DIRS` via `environment.sessionVariables`.
- Imported by the common module set.
- Both exports deleted from `.zshrc`.

## Why $HOME-literal

`environment.sessionVariables` renders into `/etc/pam/environment`, where NixOS rewrites `$HOME` → pam_env's `@{HOME}`. The old `.zshrc` values referenced `$XDG_CONFIG_HOME`/`$XDG_DATA_HOME`, which are defined only in interactive zsh; pam_env supports neither those nor `${VAR:-default}` fallbacks. Verified render:

```
COPILOT_HOME   DEFAULT="@{HOME}/.config/copilot"
COPILOT_SKILLS_DIRS   DEFAULT="@{HOME}/.local/share/agents/skills"
```

## Verification

- `nix eval` of `COPILOT_HOME` + toplevel `drvPath` for all three hosts (DansSpectre, New-H0Ryzen, WSL --impure) ✅
- `nix flake check --impure` → all checks passed ✅

## Not covered here (needs manual action post-merge)

- `~/.copilot/` removal is a one-off manual `rm -rf` per the spec (non-declarative); still present on this machine.
- Runtime acceptance checks (`sh -c 'echo $COPILOT_HOME'`) only take effect after `nixos-rebuild switch`.

## Known trade-off

`sessionVariables` (pam_env) reaches login/PAM sessions but **not** system-level systemd units started outside a login session. This matches the spec's explicit direction to use `environment.sessionVariables`; the checkboxed acceptance criteria (`sh -c`) are satisfied. Flagging for awareness if system-unit coverage is later required.