### PR TITLE
✨ feat(opencode): block install-class anti-pattern at execution time

### DIFF
--- a/opencode/.config/opencode/lib/nix-native-guard.ts
+++ b/opencode/.config/opencode/lib/nix-native-guard.ts
@@ -31,7 +31,7 @@ const BLOCKERS: { rule: RuleId; test: (cmd: string) => boolean }[] = [
   {
     rule: "global-npm-install",
     test: (cmd) =>
-      /\bnpm\s+(?:i|in|install|add)\b[^&|;\n]*?\s(?:-g|--global)\b/.test(cmd),
+      /\bnpm\s+(?:i|in|install|add)\b[^&|;\n]*?\s(?:-g|--global)(?=\s|$)/.test(cmd),
   },
   { rule: "pipx-install", test: (cmd) => /\bpipx\s+install\b/.test(cmd) },
   { rule: "cargo-install", test: (cmd) => /\bcargo\s+install\b/.test(cmd) },
@@ -41,8 +41,14 @@ const BLOCKERS: { rule: RuleId; test: (cmd: string) => boolean }[] = [
     test: (cmd) => {
       if (!PIP_INSTALL.test(cmd)) return false;
       // Only a command-string-visible venv exempts pip; process env-var venv state is unreliable here.
-      const venvForm = VENV_PATH_PIP.test(cmd) || VENV_ACTIVATE.test(cmd);
-      return !(venvForm && PIP_REQUIREMENT.test(cmd));
+      const venvActive = VENV_ACTIVATE.test(cmd);
+      // The -r must belong to the pip call itself, so evaluate each pip segment on its own.
+      for (const segment of cmd.split(/[;&|\n]+/)) {
+        if (!PIP_INSTALL.test(segment)) continue;
+        const venvForm = venvActive || VENV_PATH_PIP.test(segment);
+        if (!(venvForm && PIP_REQUIREMENT.test(segment))) return true;
+      }
+      return false;
     },
   },
 ];

--- a/opencode/.config/opencode/lib/nix-native-guard.ts
+++ b/opencode/.config/opencode/lib/nix-native-guard.ts
@@ -4,29 +4,34 @@ export type RuleId =
   | "pipx-install"
   | "cargo-install"
   | "go-install"
-  | "bare-pip-install"
+  | "bare-pip-install";
 
 export interface GuardResult {
-  blocked: boolean
-  rule?: RuleId
-  reason?: string
+  blocked: boolean;
+  rule?: RuleId;
+  reason?: string;
 }
 
-const ALLOW: GuardResult = { blocked: false }
+const ALLOW: GuardResult = { blocked: false };
 
-const VENV_PATH_PIP = /(?:^|[\s;&|=(])(?:\.\/)?\.?venv\/bin\/pip[0-9.]*\s+install\b/
-const VENV_ACTIVATE = /(?:^|[\s;&|])(?:source|\.)\s+\S*activate\b/
-const PIP_INSTALL = /\bpip[0-9.]*\s+install\b/
-const PIP_REQUIREMENT = /(?:^|\s)(?:-r|--requirement)\b/
+const VENV_PATH_PIP =
+  /(?:^|[\s;&|=(])(?:\.\/)?\.?venv\/bin\/pip[0-9.]*\s+install\b/;
+const VENV_ACTIVATE = /(?:^|[\s;&|])(?:source|\.)\s+\S*activate\b/;
+const PIP_INSTALL = /\bpip[0-9.]*\s+install\b/;
+const PIP_REQUIREMENT = /(?:^|\s)(?:-r|--requirement)\b/;
 
 const BLOCKERS: { rule: RuleId; test: (cmd: string) => boolean }[] = [
   {
     rule: "pipe-to-shell",
-    test: (cmd) => /\b(?:curl|wget)\b.*\|\s*(?:sudo\s+)?(?:sh|bash|zsh|dash|ksh|fish)\b/is.test(cmd),
+    test: (cmd) =>
+      /\b(?:curl|wget)\b.*\|\s*(?:sudo\s+)?(?:sh|bash|zsh|dash|ksh|fish)\b/is.test(
+        cmd,
+      ),
   },
   {
     rule: "global-npm-install",
-    test: (cmd) => /\bnpm\s+(?:i|in|install|add)\b[^&|;\n]*?\s(?:-g|--global)\b/.test(cmd),
+    test: (cmd) =>
+      /\bnpm\s+(?:i|in|install|add)\b[^&|;\n]*?\s(?:-g|--global)\b/.test(cmd),
   },
   { rule: "pipx-install", test: (cmd) => /\bpipx\s+install\b/.test(cmd) },
   { rule: "cargo-install", test: (cmd) => /\bcargo\s+install\b/.test(cmd) },
@@ -34,21 +39,21 @@ const BLOCKERS: { rule: RuleId; test: (cmd: string) => boolean }[] = [
   {
     rule: "bare-pip-install",
     test: (cmd) => {
-      if (!PIP_INSTALL.test(cmd)) return false
+      if (!PIP_INSTALL.test(cmd)) return false;
       // Only a command-string-visible venv exempts pip; process env-var venv state is unreliable here.
-      const venvForm = VENV_PATH_PIP.test(cmd) || VENV_ACTIVATE.test(cmd)
-      return !(venvForm && PIP_REQUIREMENT.test(cmd))
+      const venvForm = VENV_PATH_PIP.test(cmd) || VENV_ACTIVATE.test(cmd);
+      return !(venvForm && PIP_REQUIREMENT.test(cmd));
     },
   },
-]
+];
 
 const MESSAGE =
-  "Blocked: this is an imperative, un-reproducible install. Follow the nix-native dependency workflow — run the tool ephemerally (`nix run nixpkgs#<pkg>` / `nix shell nixpkgs#<pkg>`) or propose adding it to the Nix config. See nix-native-deps guidance."
+  "Blocked: this is an imperative, un-reproducible install. Follow the nix-native dependency workflow — run the tool ephemerally (`nix run nixpkgs#<pkg>` / `nix shell nixpkgs#<pkg>`) or propose adding it to the Nix config. See nix-native-deps guidance.";
 
 export function evaluateBashCommand(command: string): GuardResult {
-  if (typeof command !== "string" || command.length === 0) return ALLOW
+  if (typeof command !== "string" || command.length === 0) return ALLOW;
   for (const { rule, test } of BLOCKERS) {
-    if (test(command)) return { blocked: true, rule, reason: MESSAGE }
+    if (test(command)) return { blocked: true, rule, reason: MESSAGE };
   }
-  return ALLOW
+  return ALLOW;
 }

--- a/opencode/.config/opencode/lib/nix-native-guard.ts
+++ b/opencode/.config/opencode/lib/nix-native-guard.ts
@@ -1,0 +1,54 @@
+export type RuleId =
+  | "pipe-to-shell"
+  | "global-npm-install"
+  | "pipx-install"
+  | "cargo-install"
+  | "go-install"
+  | "bare-pip-install"
+
+export interface GuardResult {
+  blocked: boolean
+  rule?: RuleId
+  reason?: string
+}
+
+const ALLOW: GuardResult = { blocked: false }
+
+const VENV_PATH_PIP = /(?:^|[\s;&|=(])(?:\.\/)?\.?venv\/bin\/pip[0-9.]*\s+install\b/
+const VENV_ACTIVATE = /(?:^|[\s;&|])(?:source|\.)\s+\S*activate\b/
+const PIP_INSTALL = /\bpip[0-9.]*\s+install\b/
+const PIP_REQUIREMENT = /(?:^|\s)(?:-r|--requirement)\b/
+
+const BLOCKERS: { rule: RuleId; test: (cmd: string) => boolean }[] = [
+  {
+    rule: "pipe-to-shell",
+    test: (cmd) => /\b(?:curl|wget)\b.*\|\s*(?:sudo\s+)?(?:sh|bash|zsh|dash|ksh|fish)\b/is.test(cmd),
+  },
+  {
+    rule: "global-npm-install",
+    test: (cmd) => /\bnpm\s+(?:i|in|install|add)\b[^&|;\n]*?\s(?:-g|--global)\b/.test(cmd),
+  },
+  { rule: "pipx-install", test: (cmd) => /\bpipx\s+install\b/.test(cmd) },
+  { rule: "cargo-install", test: (cmd) => /\bcargo\s+install\b/.test(cmd) },
+  { rule: "go-install", test: (cmd) => /\bgo\s+install\b/.test(cmd) },
+  {
+    rule: "bare-pip-install",
+    test: (cmd) => {
+      if (!PIP_INSTALL.test(cmd)) return false
+      // Only a command-string-visible venv exempts pip; process env-var venv state is unreliable here.
+      const venvForm = VENV_PATH_PIP.test(cmd) || VENV_ACTIVATE.test(cmd)
+      return !(venvForm && PIP_REQUIREMENT.test(cmd))
+    },
+  },
+]
+
+const MESSAGE =
+  "Blocked: this is an imperative, un-reproducible install. Follow the nix-native dependency workflow — run the tool ephemerally (`nix run nixpkgs#<pkg>` / `nix shell nixpkgs#<pkg>`) or propose adding it to the Nix config. See nix-native-deps guidance."
+
+export function evaluateBashCommand(command: string): GuardResult {
+  if (typeof command !== "string" || command.length === 0) return ALLOW
+  for (const { rule, test } of BLOCKERS) {
+    if (test(command)) return { blocked: true, rule, reason: MESSAGE }
+  }
+  return ALLOW
+}

--- a/opencode/.config/opencode/lib/nix-native-guard.ts
+++ b/opencode/.config/opencode/lib/nix-native-guard.ts
@@ -31,7 +31,7 @@ const BLOCKERS: { rule: RuleId; test: (cmd: string) => boolean }[] = [
   {
     rule: "global-npm-install",
     test: (cmd) =>
-      /\bnpm\s+(?:i|in|install|add)\b[^&|;\n]*?\s(?:-g|--global)(?=\s|$)/.test(cmd),
+      /\bnpm\s+(?:install|isntall|instal|isntal|insta|isnta|inst|isnt|ins|add|in|i)\b[^&|;\n]*?\s(?:-g|--global)(?=\s|$)/.test(cmd),
   },
   { rule: "pipx-install", test: (cmd) => /\bpipx\s+install\b/.test(cmd) },
   { rule: "cargo-install", test: (cmd) => /\bcargo\s+install\b/.test(cmd) },

--- a/opencode/.config/opencode/opencode.json
+++ b/opencode/.config/opencode/opencode.json
@@ -11,6 +11,33 @@
     "paths": ["~/.local/share/agents/skills"]
   },
   "instructions": ["{env:HOME}/.config/agents/nix-native-deps.md"],
+  "permission": {
+    "bash": {
+      "npm i -g*": "deny",
+      "npm install -g*": "deny",
+      "npm i --global*": "deny",
+      "npm install --global*": "deny",
+      "npm i * -g*": "deny",
+      "npm install * -g*": "deny",
+      "npm i * --global*": "deny",
+      "npm install * --global*": "deny",
+      "pip install*": "deny",
+      "pip3 install*": "deny",
+      "python -m pip install*": "deny",
+      "python3 -m pip install*": "deny",
+      "pipx install*": "deny",
+      "cargo install*": "deny",
+      "go install*": "deny",
+      "curl * | sh*": "deny",
+      "curl * | bash*": "deny",
+      "wget * | sh*": "deny",
+      "wget * | bash*": "deny",
+      "pip install -r*": "allow",
+      "pip3 install -r*": "allow",
+      "python -m pip install -r*": "allow",
+      "python3 -m pip install -r*": "allow"
+    }
+  },
   "formatter": true,
   "autoupdate": false
 }

--- a/opencode/.config/opencode/plugins/nix-native-guard.ts
+++ b/opencode/.config/opencode/plugins/nix-native-guard.ts
@@ -1,15 +1,15 @@
-import type { Plugin } from "@opencode-ai/plugin"
+import type { Plugin } from "@opencode-ai/plugin";
 
-import { evaluateBashCommand } from "../lib/nix-native-guard.ts"
+import { evaluateBashCommand } from "../lib/nix-native-guard.ts";
 
 export const NixNativeGuardPlugin: Plugin = async () => {
   return {
     "tool.execute.before": async (input, output) => {
-      if (input.tool !== "bash") return
-      const command = output.args?.command
-      if (typeof command !== "string") return
-      const result = evaluateBashCommand(command)
-      if (result.blocked) throw new Error(result.reason)
+      if (input.tool !== "bash") return;
+      const command = output.args?.command;
+      if (typeof command !== "string") return;
+      const result = evaluateBashCommand(command);
+      if (result.blocked) throw new Error(result.reason);
     },
-  }
-}
+  };
+};

--- a/opencode/.config/opencode/plugins/nix-native-guard.ts
+++ b/opencode/.config/opencode/plugins/nix-native-guard.ts
@@ -1,0 +1,15 @@
+import type { Plugin } from "@opencode-ai/plugin"
+
+import { evaluateBashCommand } from "../lib/nix-native-guard.ts"
+
+export const NixNativeGuardPlugin: Plugin = async () => {
+  return {
+    "tool.execute.before": async (input, output) => {
+      if (input.tool !== "bash") return
+      const command = output.args?.command
+      if (typeof command !== "string") return
+      const result = evaluateBashCommand(command)
+      if (result.blocked) throw new Error(result.reason)
+    },
+  }
+}

--- a/opencode/.config/opencode/plugins/terminal-bell.ts
+++ b/opencode/.config/opencode/plugins/terminal-bell.ts
@@ -1,13 +1,13 @@
-import type { Plugin } from "@opencode-ai/plugin"
+import type { Plugin } from "@opencode-ai/plugin";
 
-const BELL = "\x07"
+const BELL = "\x07";
 
 export const TerminalBellPlugin: Plugin = async () => {
   return {
     event: async ({ event }) => {
       if (event.type === "session.idle" || event.type === "permission.asked") {
-        process.stdout.write(BELL)
+        process.stdout.write(BELL);
       }
     },
-  }
-}
+  };
+};

--- a/opencode/.config/opencode/test/nix-native-guard.test.ts
+++ b/opencode/.config/opencode/test/nix-native-guard.test.ts
@@ -1,84 +1,94 @@
-import { describe, it } from "node:test"
-import assert from "node:assert/strict"
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
 
-import { evaluateBashCommand } from "../lib/nix-native-guard.ts"
+import { evaluateBashCommand } from "../lib/nix-native-guard.ts";
 
 const blocked = (cmd: string) =>
-  assert.equal(evaluateBashCommand(cmd).blocked, true, `expected BLOCK: ${cmd}`)
+  assert.equal(
+    evaluateBashCommand(cmd).blocked,
+    true,
+    `expected BLOCK: ${cmd}`,
+  );
 const allowed = (cmd: string) =>
-  assert.equal(evaluateBashCommand(cmd).blocked, false, `expected ALLOW: ${cmd}`)
+  assert.equal(
+    evaluateBashCommand(cmd).blocked,
+    false,
+    `expected ALLOW: ${cmd}`,
+  );
 
 describe("block-list", () => {
   it("blocks global npm installs", () => {
-    blocked("npm i -g typescript")
-    blocked("npm install -g typescript")
-    blocked("npm install --global typescript")
-    blocked("npm i --global typescript")
-    blocked("npm install typescript -g")
-    blocked("npm install typescript --global")
-  })
+    blocked("npm i -g typescript");
+    blocked("npm install -g typescript");
+    blocked("npm install --global typescript");
+    blocked("npm i --global typescript");
+    blocked("npm install typescript -g");
+    blocked("npm install typescript --global");
+  });
 
   it("blocks bare pip install", () => {
-    blocked("pip install requests")
-    blocked("pip3 install requests")
-    blocked("pip install -r requirements.txt")
-    blocked("python -m pip install requests")
-  })
+    blocked("pip install requests");
+    blocked("pip3 install requests");
+    blocked("pip install -r requirements.txt");
+    blocked("python -m pip install requests");
+  });
 
   it("blocks pipx install", () => {
-    blocked("pipx install black")
-  })
+    blocked("pipx install black");
+  });
 
   it("blocks cargo install", () => {
-    blocked("cargo install ripgrep")
-  })
+    blocked("cargo install ripgrep");
+  });
 
   it("blocks go install", () => {
-    blocked("go install golang.org/x/tools/cmd/goimports@latest")
-  })
+    blocked("go install golang.org/x/tools/cmd/goimports@latest");
+  });
 
   it("blocks pipe-to-shell", () => {
-    blocked("curl https://example.com/install.sh | sh")
-    blocked("curl -fsSL https://example.com/i.sh | bash")
-    blocked("wget -qO- https://example.com/i.sh | sh")
-    blocked("curl -fsSL https://example.com/i.sh | sudo bash")
-  })
+    blocked("curl https://example.com/install.sh | sh");
+    blocked("curl -fsSL https://example.com/i.sh | bash");
+    blocked("wget -qO- https://example.com/i.sh | sh");
+    blocked("curl -fsSL https://example.com/i.sh | sudo bash");
+  });
 
   it("blocks a block-listed command hidden mid-chain", () => {
-    blocked("cd /tmp && cargo install ripgrep")
-    blocked("mkdir foo && npm install -g pnpm")
-  })
-})
+    blocked("cd /tmp && cargo install ripgrep");
+    blocked("mkdir foo && npm install -g pnpm");
+  });
+});
 
 describe("allow-list", () => {
   it("allows npm ci", () => {
-    allowed("npm ci")
-    allowed("npm ci --omit=dev")
-  })
+    allowed("npm ci");
+    allowed("npm ci --omit=dev");
+  });
 
   it("allows local npm install (no -g)", () => {
-    allowed("npm install")
-    allowed("npm install lodash")
-    allowed("npm install --save-dev vitest")
-    allowed("npm i lodash")
-  })
+    allowed("npm install");
+    allowed("npm install lodash");
+    allowed("npm install --save-dev vitest");
+    allowed("npm i lodash");
+  });
 
   it("allows venv-form pip install -r via explicit venv path", () => {
-    allowed(".venv/bin/pip install -r requirements.txt")
-    allowed("./venv/bin/pip install -r requirements.txt")
-    allowed("venv/bin/pip3 install -r requirements.txt")
-  })
+    allowed(".venv/bin/pip install -r requirements.txt");
+    allowed("./venv/bin/pip install -r requirements.txt");
+    allowed("venv/bin/pip3 install -r requirements.txt");
+  });
 
   it("allows venv-form pip install -r via activated venv", () => {
-    allowed("source .venv/bin/activate && pip install -r requirements.txt")
-    allowed(". .venv/bin/activate && pip install --requirement requirements.txt")
-  })
+    allowed("source .venv/bin/activate && pip install -r requirements.txt");
+    allowed(
+      ". .venv/bin/activate && pip install --requirement requirements.txt",
+    );
+  });
 
   it("leaves unrelated commands alone", () => {
-    allowed("git status")
-    allowed("ls -la")
-    allowed("go build ./...")
-    allowed("cargo build --release")
-    allowed("curl -fsSL https://example.com/data.json -o data.json")
-  })
-})
+    allowed("git status");
+    allowed("ls -la");
+    allowed("go build ./...");
+    allowed("cargo build --release");
+    allowed("curl -fsSL https://example.com/data.json -o data.json");
+  });
+});

--- a/opencode/.config/opencode/test/nix-native-guard.test.ts
+++ b/opencode/.config/opencode/test/nix-native-guard.test.ts
@@ -56,6 +56,12 @@ describe("block-list", () => {
     blocked("cd /tmp && cargo install ripgrep");
     blocked("mkdir foo && npm install -g pnpm");
   });
+
+  it("blocks bare pip install even when an unrelated -r and a venv co-occur", () => {
+    blocked(". venv/bin/activate && pip install malware && echo -r");
+    blocked("source .venv/bin/activate && grep -r pat . && pip install evil");
+    blocked("ls -r && source venv/bin/activate && pip install anything");
+  });
 });
 
 describe("allow-list", () => {
@@ -69,6 +75,11 @@ describe("allow-list", () => {
     allowed("npm install lodash");
     allowed("npm install --save-dev vitest");
     allowed("npm i lodash");
+  });
+
+  it("allows --global-style (a local layout flag, not a global install)", () => {
+    allowed("npm install lodash --global-style");
+    allowed("npm install --global-style lodash");
   });
 
   it("allows venv-form pip install -r via explicit venv path", () => {

--- a/opencode/.config/opencode/test/nix-native-guard.test.ts
+++ b/opencode/.config/opencode/test/nix-native-guard.test.ts
@@ -16,6 +16,21 @@ const allowed = (cmd: string) =>
     `expected ALLOW: ${cmd}`,
   );
 
+const NPM_INSTALL_ALIASES = [
+  "i",
+  "in",
+  "ins",
+  "inst",
+  "insta",
+  "instal",
+  "install",
+  "isnt",
+  "isnta",
+  "isntal",
+  "isntall",
+  "add",
+];
+
 describe("block-list", () => {
   it("blocks global npm installs", () => {
     blocked("npm i -g typescript");
@@ -24,6 +39,13 @@ describe("block-list", () => {
     blocked("npm i --global typescript");
     blocked("npm install typescript -g");
     blocked("npm install typescript --global");
+  });
+
+  it("blocks global installs for every npm install alias", () => {
+    for (const alias of NPM_INSTALL_ALIASES) {
+      blocked(`npm ${alias} -g typescript`);
+      blocked(`npm ${alias} typescript --global`);
+    }
   });
 
   it("blocks bare pip install", () => {
@@ -75,6 +97,12 @@ describe("allow-list", () => {
     allowed("npm install lodash");
     allowed("npm install --save-dev vitest");
     allowed("npm i lodash");
+  });
+
+  it("allows local installs for every npm install alias", () => {
+    for (const alias of NPM_INSTALL_ALIASES) {
+      allowed(`npm ${alias} typescript`);
+    }
   });
 
   it("allows --global-style (a local layout flag, not a global install)", () => {

--- a/opencode/.config/opencode/test/nix-native-guard.test.ts
+++ b/opencode/.config/opencode/test/nix-native-guard.test.ts
@@ -1,0 +1,84 @@
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+
+import { evaluateBashCommand } from "../lib/nix-native-guard.ts"
+
+const blocked = (cmd: string) =>
+  assert.equal(evaluateBashCommand(cmd).blocked, true, `expected BLOCK: ${cmd}`)
+const allowed = (cmd: string) =>
+  assert.equal(evaluateBashCommand(cmd).blocked, false, `expected ALLOW: ${cmd}`)
+
+describe("block-list", () => {
+  it("blocks global npm installs", () => {
+    blocked("npm i -g typescript")
+    blocked("npm install -g typescript")
+    blocked("npm install --global typescript")
+    blocked("npm i --global typescript")
+    blocked("npm install typescript -g")
+    blocked("npm install typescript --global")
+  })
+
+  it("blocks bare pip install", () => {
+    blocked("pip install requests")
+    blocked("pip3 install requests")
+    blocked("pip install -r requirements.txt")
+    blocked("python -m pip install requests")
+  })
+
+  it("blocks pipx install", () => {
+    blocked("pipx install black")
+  })
+
+  it("blocks cargo install", () => {
+    blocked("cargo install ripgrep")
+  })
+
+  it("blocks go install", () => {
+    blocked("go install golang.org/x/tools/cmd/goimports@latest")
+  })
+
+  it("blocks pipe-to-shell", () => {
+    blocked("curl https://example.com/install.sh | sh")
+    blocked("curl -fsSL https://example.com/i.sh | bash")
+    blocked("wget -qO- https://example.com/i.sh | sh")
+    blocked("curl -fsSL https://example.com/i.sh | sudo bash")
+  })
+
+  it("blocks a block-listed command hidden mid-chain", () => {
+    blocked("cd /tmp && cargo install ripgrep")
+    blocked("mkdir foo && npm install -g pnpm")
+  })
+})
+
+describe("allow-list", () => {
+  it("allows npm ci", () => {
+    allowed("npm ci")
+    allowed("npm ci --omit=dev")
+  })
+
+  it("allows local npm install (no -g)", () => {
+    allowed("npm install")
+    allowed("npm install lodash")
+    allowed("npm install --save-dev vitest")
+    allowed("npm i lodash")
+  })
+
+  it("allows venv-form pip install -r via explicit venv path", () => {
+    allowed(".venv/bin/pip install -r requirements.txt")
+    allowed("./venv/bin/pip install -r requirements.txt")
+    allowed("venv/bin/pip3 install -r requirements.txt")
+  })
+
+  it("allows venv-form pip install -r via activated venv", () => {
+    allowed("source .venv/bin/activate && pip install -r requirements.txt")
+    allowed(". .venv/bin/activate && pip install --requirement requirements.txt")
+  })
+
+  it("leaves unrelated commands alone", () => {
+    allowed("git status")
+    allowed("ls -la")
+    allowed("go build ./...")
+    allowed("cargo build --release")
+    allowed("curl -fsSL https://example.com/data.json -o data.json")
+  })
+})


### PR DESCRIPTION
## Summary

Makes opencode **block** the install-class anti-pattern at execution time, enforcing the nix-native dependency workflow ([spec](https://github.com/dandyrow/dotfiles/blob/main/agents/.config/agents/nix-native-deps.md), PR #101) rather than merely advising it. Two layers, per decision #96:

- **Primary** — a `tool.execute.before` plugin (`opencode/.config/opencode/plugins/nix-native-guard.ts`) that regex-classifies the bash command string and `throw`s before execution, routing the agent to the nix workflow. The classification is a pure function (`lib/nix-native-guard.ts`) unit-tested with `node:test`; the plugin is a thin adapter.
- **Backstop** — `permission.bash` deny rules in `opencode.json` for the same commands.

### Block-list
`npm i -g` / `npm install -g` / `--global`, bare `pip install`, `pipx install`, `cargo install`, `go install`, `curl … | sh` (and `wget … | sh`).

### Allow-list
`npm ci`, local `npm install` (no `-g`), and `pip install -r` **only** in an explicit command-string venv form (`.venv/bin/pip …` / activated `source …/activate && pip …`). Env-var venv detection was rejected as unreliable (fresh subprocess per bash call), so the allow decision keys solely on the visible command string.

## Acceptance criteria
- [x] Each block-listed command is rejected by the plugin before execution — covered by unit tests.
- [x] `permission.bash` deny rules independently reject the same commands (see limitations below).
- [x] Each allow-listed command (`npm ci`, local `npm install`, venv-form `pip install -r`) is permitted.
- [x] `nix flake check` passes.

## Known backstop limitations (primary plugin is authoritative)
- The glob backstop cannot verify venv-form, so `pip install -r*` is allowed unconditionally there to avoid denying the allow-listed activated-venv case. Bare `pip install -r` therefore leaks past the backstop, but the primary plugin blocks it (it requires venv-form + `-r`).
- opencode parses pipelines per-command, so the `curl … | sh` deny globs may not fire at the permission layer; the plugin (which sees the raw `output.args.command`) is what actually enforces pipe-to-shell.

This matches decision #96's framing of the backstop as "cheap defense-in-depth", with the plugin as the real enforcement.

## Testing
- `node --test test/nix-native-guard.test.ts` — 12 tests, all pass.
- `tsc --noEmit --strict` on the plugin + core — clean.
- `nix flake check` — all checks pass.

Closes #104.

Co-authored-by: Copilot <copilot@github.com>