### PR TITLE
✨ feat(copilot): load machine-global nix-native guidance

### DIFF
--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -130,6 +130,10 @@ in
         ".local/share/gnupg/gpg.conf".source = mkLink "gnupg/.local/share/gnupg/gpg.conf";
         ".local/share/gnupg/gpg-agent.conf".source = mkLink "gnupg/.local/share/gnupg/gpg-agent.conf";
         ".config/copilot/mcp-config.json".source = mkLink "copilot/.config/copilot/mcp-config.json";
+
+        # Copilot only reads instructions from $COPILOT_HOME/copilot-instructions.md — no home-level AGENTS.md.
+        ".config/copilot/copilot-instructions.md".source =
+          config.lib.file.mkOutOfStoreSymlink "${config.xdg.configHome}/agents/nix-native-deps.md";
       }
 
       # Per-file symlinks are used here instead of mkConfigLink so that home-manager


### PR DESCRIPTION
## What

Symlinks `~/.config/copilot/copilot-instructions.md` to the shared agents hub (`~/.config/agents/nix-native-deps.md`) via home-manager, so Copilot loads the same machine-global nix-native dependency guidance as opencode.

Copilot has no home-level `AGENTS.md`; it reads instructions only from `$COPILOT_HOME/copilot-instructions.md`. Pointing that at the shared hub (created by `mkConfigLink "agents"`) keeps a single source of truth across both agents.

`mkOutOfStoreSymlink` is used rather than a store copy so the link targets `~/.config/agents` (itself a live out-of-store symlink), letting the two-hop chain resolve at runtime.

## Acceptance criteria

- [x] After a rebuild, `~/.config/copilot/copilot-instructions.md` resolves to `~/.config/agents/nix-native-deps.md` — verified via `nix eval` of the home-manager file source; final resolution materializes on `nixos-rebuild switch`.
- [x] Copilot launched non-interactively picks up the guidance — enabled by #103 (PR #108, now merged), which makes `COPILOT_HOME` authoritative in every launch context. This branch is rebased on top of #108.
- [x] `nix flake check` passes (all three hosts + wsl-tarball).

## Verification

- `nix eval` of all three hosts (`DansSpectre`, `New-H0Ryzen`, `WSL --impure`) — all evaluate.
- `nix flake check --impure` — all checks passed.
- Post-`switch` check for the user to run: `readlink ~/.config/copilot/copilot-instructions.md` should print `~/.config/agents/nix-native-deps.md`, and `sh -c 'cat "$COPILOT_HOME/copilot-instructions.md"' | head` should show the nix-native spec.

Closes #105.

Co-authored-by: Copilot <copilot@github.com>