### PR TITLE
✨ feat(home): open browser from WSL via wsl-open

### DIFF
--- a/docs/adr/0001-wsl-browser-opener.md
+++ b/docs/adr/0001-wsl-browser-opener.md
@@ -1,0 +1,70 @@
+# ADR-0001: Open browsers from WSL via `wsl-open`, not a Linux GUI browser
+
+- **Status:** Accepted
+- **Date:** 2026-07-17
+- **Scope:** WSL host (`nix/hosts/WSL`), home module (`nix/home/default.nix`)
+
+## Context
+
+On the WSL host the standard opener path is dead on arrival: `xdg-open` is
+not on `PATH` and `$BROWSER` is empty. Apps that opened the browser did so
+only by hard-coding a Windows `.exe` (`explorer.exe`, `powershell.exe Start`)
+through binfmt interop. Anything using the generic `xdg-open` / `$BROWSER`
+path — including agent tooling that writes to `/tmp` and calls `xdg-open` —
+failed silently.
+
+The goal was a single, generic, reliable opener reachable through that
+standard path. Two broad routes existed:
+
+- **(a) Hand off to the Windows browser** via interop.
+- **(b) Run a Linux GUI browser under WSLg** and register it as the
+  `xdg-open` handler, mirroring the desktop `hasDesktop` Firefox wiring.
+
+`wslu` (the usual source of `wslview`) has been removed from nixpkgs — the
+project is archived — so that specific tool is not an option.
+
+## Decision
+
+Route to the **Windows default browser** via `pkgs.wsl-open`, gated on
+`osConfig.wsl.enable` in the shared home module. Set `BROWSER=wsl-open` and
+alias `xdg-open` → `wsl-open` so both integration paths resolve to the same
+opener. `wsl-open` converts WSL paths and copies non-Windows-filesystem
+files to Windows `%TEMP%` when needed, then opens via `powershell.exe Start`.
+
+## Wayland / X11 considerations
+
+Avoiding X11 was a hard constraint, and it drove the choice of route (a):
+
+- Route (b) means running a Linux browser under **WSLg**, which provides a
+  Wayland compositor *and* an XWayland (X11) server. Even a Wayland-native
+  Firefox drags a GUI stack into the WSL closure, and many GUI helpers still
+  fall back to XWayland — exactly the X11 surface we want to keep out.
+- Route (a) runs **no Linux GUI at all** — the browser lives on the Windows
+  side — so it introduces **zero Linux display-server dependency**, X11 or
+  Wayland. This is the cleanest way to honour "avoid X11": there is simply no
+  Linux display stack in play.
+- This keeps WSL consistent with the repo's Wayland-leaning desktop posture
+  (`wl-clipboard`, no X11 clipboard) by not smuggling X11 in as a side effect.
+- **If** a future need requires an actual Linux GUI under WSL, prefer WSLg's
+  Wayland path and run apps Wayland-native (e.g. `MOZ_ENABLE_WAYLAND=1`),
+  explicitly avoiding XWayland — and revisit this ADR then.
+
+## Consequences
+
+- Reliable generic opening through the standard `xdg-open` / `$BROWSER` path.
+- No Linux display stack (X11 *or* Wayland) added to the WSL closure.
+- One seam, gated on `wsl.enable`, colocated with the desktop browser wiring.
+- Tradeoff: opens the *Windows* browser rather than a Linux one — desired on
+  WSL. Depends on `wsl-open` (a small, maintained shell script) plus
+  `powershell.exe` interop.
+- `xdg-open` is shadowed by a WSL-aware replacement rather than real
+  `xdg-utils`. Correct on a headless WSL host with no mime database to defer
+  to; note this if a real desktop mime system is ever wanted here.
+
+## Alternatives considered
+
+- **`wslu` / `wslview`** — removed from nixpkgs (project archived). Rejected.
+- **Real `xdg-utils` + `xdg.mimeApps` handler** — needs `.desktop` files and a
+  working mime database; fragile on a headless WSL host. Rejected.
+- **Linux browser under WSLg** — risks pulling in X11 via XWayland, heavier
+  closure, contrary to the avoid-X11 constraint. Rejected.

--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -12,6 +12,13 @@ let
   mkLink = relPath: config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/${relPath}";
   mkConfigLink = name: { ".config/${name}".source = mkLink "${name}/.config/${name}"; };
   hasDesktop = osConfig != null && (osConfig.gnome.enable or false);
+  isWSL = osConfig != null && (osConfig.wsl.enable or false);
+
+  # WSL ships no xdg-open — alias it to wsl-open so xdg-open callers reach the Windows browser.
+  wslXdgOpen = pkgs.runCommand "xdg-open-wsl" { } ''
+    mkdir -p $out/bin
+    ln -s ${pkgs.wsl-open}/bin/wsl-open $out/bin/xdg-open
+  '';
 
   nvimToolsJson = builtins.fromJSON (builtins.readFile ../../nvim/.config/nvim/lua/config/tools.json);
   nvimToolAttrs = lib.unique (
@@ -28,6 +35,10 @@ in
     username = "dandyrow";
     homeDirectory = "/home/dandyrow";
     stateVersion = "25.11";
+
+    sessionVariables = lib.optionalAttrs isWSL {
+      BROWSER = "wsl-open";
+    };
 
     packages =
       with pkgs;
@@ -58,6 +69,10 @@ in
           status-area-horizontal-spacing
         ]
       )
+      ++ lib.optionals isWSL [
+        pkgs.wsl-open
+        wslXdgOpen
+      ]
       ++ [
         # Zsh dependencies (see zsh dotfile README)
         fzf


### PR DESCRIPTION
## What

Make \"open a URL / HTML file in the Windows browser\" work reliably and generically from WSL via the standard \`xdg-open\` / \`\$BROWSER\` path — not per-app \`explorer.exe\` shims.

## Why

On the WSL host, `xdg-open` is **not on PATH** and `$BROWSER` is **empty**. Only apps that hard-code a Windows `.exe` (via binfmt interop) opened the browser; anything using the standard opener path — including agent tooling like the architecture-review flow that writes to `/tmp` and calls `xdg-open` — failed silently.

## How

Gated on `osConfig.wsl.enable` in the shared home module (alongside the existing `hasDesktop` browser wiring):

- add `pkgs.wsl-open` — hands URLs and files to the Windows default app via `powershell.exe Start`, converting WSL paths (and copying non-Windows-fs files to Windows `%TEMP%` when needed)
- set `BROWSER=wsl-open` for `$BROWSER`-respecting apps
- alias `xdg-open` → `wsl-open` so `xdg-open` callers work too

`wslu` (the usual `wslview` source) was removed from nixpkgs (project archived), so `wsl-open` is the maintained alternative. On a headless WSL host a WSL-aware `xdg-open` replacement is correct — there's no real desktop mime system to defer to.

## Verification

- `nix eval` of all three hosts (`WSL` with `--impure`, `DansSpectre`, `New-H0Ryzen`) succeeds.
- Runtime: `wsl-open /tmp/test.html` opened the file in the Windows default browser end-to-end on the WSL host (user-confirmed).

Runtime wiring of `BROWSER` / `xdg-open` into the session only takes effect after `nixos-rebuild switch`; the eval + direct `wsl-open` test cover everything verifiable pre-switch.